### PR TITLE
Reduce events in hysteresis

### DIFF
--- a/Modelica 3.2.1/Blocks/Logical.mo
+++ b/Modelica 3.2.1/Blocks/Logical.mo
@@ -556,7 +556,8 @@ u1, else it is set equal to u3.</p>
   initial equation
     pre(y) = pre_y_start;
   equation
-    y = u > uHigh or pre(y) and u >= uLow;
+    assert(uHigh>uLow,"Hysteresis limits wrong. uHigh="+String(uHigh)+", uHigh="+String(uLow)+ ".");
+    y = u > uHigh - (if pre(y) then uHigh-uLow else 0);
     annotation (
       Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
               100,100}}), graphics={Polygon(


### PR DESCRIPTION
I added an assert to make sure the limits make sense.

I slightly changed the formulation of the switching condition. It does not change the result, but significantly reduces the number of events (30...50%) as it does not generate unnecessary events when u falls below the upper limit (which does not result in any action anyway). 

This change helped me a lot in one particular case where in spite of the hysteresis the simulation advanced very slowly. Maybe there is something I don't understand about events, IMO if nothing happens, no event is needed. 

I hope I didn't miss anything. I've used this fix for a while and it works as expected.
Run this model to see the difference:
```
model HysteresisTest

  Modelica.Blocks.Logical.Hysteresis
             hysteresis(uLow=-0.5, uHigh=0.5)   annotation (Placement(transformation(extent={{12,-9},
            {30,9}})));
  Modelica.Blocks.Sources.Sine Signal(freqHz=1) "temperature in warm well"
    annotation (Placement(transformation(extent={{-34,-9},{-16,9}})));
equation 

  connect(Signal.y, hysteresis.u)
    annotation (Line(points={{-15.1,0},{10.2,0}},          color={0,0,127}));
  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
            -100},{100,100}})));
end HysteresisTest;
```