### PR TITLE
Restructure ModelicaExternalC sources

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaFFT.c
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.c
@@ -30,19 +30,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Adapted to the needs of the Modelica Standard Library library:
-
-   The functions in this file are non-portable. The following #define's are used
-   to define the system calls of the operating system
-
-   __GNUC__       : GNU C compiler
-   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
-                    Useful definitions:
-                    - "static" that is all functions become static
-                      (useful if file is included with other C-sources for an
-                       embedded system)
-                    - "__declspec(dllexport)" if included in a DLL and the
-                      functions shall be visible outside of the DLL
+/* Adapted to the needs of the Modelica Standard Library:
 
    Release Notes:
       Dec. 02, 2015: by Martin Otter, DLR
@@ -54,17 +42,10 @@
                      the function is left)
 */
 
-#ifndef MRKISS_FTR_H
-#define MRKISS_FTR_H
-
+#include "ModelicaFFT.h"
 #include <math.h>
 #include <limits.h>
-#include <stdlib.h>
 #include <string.h>
-
-#if !defined(MODELICA_EXPORT)
-#   define MODELICA_EXPORT
-#endif
 
 #define MRKISS_FFT_TMP_ALLOC malloc
 #define MRKISS_FFT_TMP_FREE free
@@ -95,24 +76,6 @@ struct mrkiss_fftr_state {
     mrkiss_fft_cpx * super_twiddles;
 };
 typedef struct mrkiss_fftr_state* mrkiss_fftr_cfg;
-
-/*
- * Non-null pointers need to be passed to external functions.
- *
- * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
- */
-#if defined(__GNUC__)
-#define MODELICA_NONNULLATTR __attribute__((nonnull))
-#else
-#define MODELICA_NONNULLATTR
-#endif
-#if !defined(__ATTR_SAL)
-#define _In_
-#define _Out_
-#endif
-
-MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
-    _Out_ double *amplitudes, _Out_ double *phases) MODELICA_NONNULLATTR;
 
 /* include from _kiss_fft_guts.h ------------------------------------------ */
 
@@ -555,7 +518,7 @@ static void mrkiss_fftr(mrkiss_fftr_cfg st, const mrkiss_fft_scalar *timedata, m
     }
 }
 
-MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
+int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
                           _Out_ double *amplitudes, _Out_ double *phases) {
 
     /* Compute real FFT with mrkiss_fftr
@@ -604,5 +567,3 @@ MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double
     }
     return 0;
 }
-
-#endif

--- a/Modelica/Resources/C-Sources/ModelicaFFT.h
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.h
@@ -1,0 +1,72 @@
+/* ModelicaFFT.h - FFT functions header
+
+   Copyright (C) 2015-2017, Modelica Association and DLR
+   Copyright (C) 2003-2010, Mark Borgerding
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the author nor the names of any contributors may be used to
+      endorse or promote products derived from this software without specific
+      prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The following #define's are available.
+
+   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
+                    Useful definition:
+                    - "__declspec(dllexport)" if included in a DLL and the
+                      functions shall be visible outside of the DLL
+*/
+
+#ifndef MODELICA_FFT_H_
+#define MODELICA_FFT_H_
+
+#include <stdlib.h>
+
+#if !defined(MODELICA_EXPORT)
+#if defined(__cplusplus)
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
+#endif
+
+/*
+ * Non-null pointers need to be passed to external functions.
+ *
+ * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
+ */
+#if defined(__GNUC__)
+#define MODELICA_NONNULLATTR __attribute__((nonnull))
+#else
+#define MODELICA_NONNULLATTR
+#endif
+#if !defined(__ATTR_SAL)
+#define _In_
+#define _Out_
+#endif
+
+MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
+    _Out_ double *amplitudes, _Out_ double *phases) MODELICA_NONNULLATTR;
+
+#endif

--- a/Modelica/Resources/C-Sources/ModelicaIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaIO.c
@@ -25,18 +25,12 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* The functions in this file are non-portable. The following #define's are used
-   to define the system calls of the operating system
+/* Definition of interface to external functions for array I/O
+   in the Modelica Standard Library:
 
-   NO_FILE_SYSTEM : A file system is not present (e.g. on dSPACE or xPC).
-   NO_LOCALE      : locale.h is not present (e.g. on AVR).
-   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
-                    Useful definitions:
-                    - "static" that is all functions become static
-                      (useful if file is included with other C-sources for an
-                       embedded system)
-                    - "__declspec(dllexport)" if included in a DLL and the
-                      functions shall be visible outside of the DLL
+      Modelica.Utilities.Streams.readMatrixSize
+      Modelica.Utilities.Streams.readRealMatrix
+      Modelica.Utilities.Streams.writeRealMatrix
 
    Release Notes:
       Mar. 08, 2017: by Thomas Beutlich, ESI ITI GmbH
@@ -55,7 +49,7 @@
                      Replaced strtok by re-entrant string tokenize function
                      (ticket #1153)
 
-      Nov. 23, 2016: by Martin Sjölund, SICS East Swedish ICT AB
+      Nov. 23, 2016: by Martin SjÃ¶lund, SICS East Swedish ICT AB
                      Added NO_LOCALE define flag, in case the OS does
                      not have this (for example when using GCC compiler,
                      but not libc). Also added autoconf detection for
@@ -69,17 +63,12 @@
                      Implemented a first version (ticket #1856)
 */
 
-#if !defined(MODELICA_EXPORT)
-  #define MODELICA_EXPORT
-#endif
-
 #if defined(__gnu_linux__) && !defined(NO_FILE_SYSTEM)
 #define _GNU_SOURCE 1
 #endif
 
-#include <stdlib.h>
-#include <string.h>
 #include "ModelicaIO.h"
+#include <string.h>
 #include "ModelicaUtilities.h"
 
 #ifdef NO_FILE_SYSTEM
@@ -91,18 +80,18 @@ static void ModelicaNotExistError(const char* name) {
         "as for dSPACE or xPC systems)\n", name);
 }
 
-MODELICA_EXPORT void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
+void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
     _In_z_ const char* matrixName, _Out_ int* dim) {
     ModelicaNotExistError("ModelicaIO_readMatrixSizes"); }
-MODELICA_EXPORT void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
+void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
     _In_z_ const char* matrixName, _Out_ double* matrix, size_t m, size_t n,
     int verbose) {
     ModelicaNotExistError("ModelicaIO_readRealMatrix"); }
-MODELICA_EXPORT int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
+int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
     _In_z_ const char* matrixName, _In_ double* matrix, size_t m, size_t n,
     int append, _In_z_ const char* version) {
     ModelicaNotExistError("ModelicaIO_writeRealMatrix"); return 0; }
-MODELICA_EXPORT double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
+double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
     _In_z_ const char* matrixName, _Out_ size_t* m, _Out_ size_t* n,
     int verbose) {
     ModelicaNotExistError("ModelicaIO_readRealTable"); return NULL; }
@@ -171,7 +160,7 @@ static int IsNumber(char* token);
 static void transpose(_Inout_ double* table, size_t nRow, size_t nCol) MODELICA_NONNULLATTR;
   /* Cycle-based in-place array transposition */
 
-MODELICA_EXPORT void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
+void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
                                 _In_z_ const char* matrixName,
                                 _Out_ int* dim) {
     MatIO matio = {NULL, NULL, NULL};
@@ -191,7 +180,7 @@ MODELICA_EXPORT void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
     (void)Mat_Close(matio.mat);
 }
 
-MODELICA_EXPORT void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
+void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
                                _Out_ double* matrix, size_t m, size_t n,
                                int verbose) {
@@ -257,7 +246,7 @@ MODELICA_EXPORT void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
     }
 }
 
-MODELICA_EXPORT int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
+int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
                                _In_ double* matrix, size_t m, size_t n,
                                int append,
@@ -333,7 +322,7 @@ MODELICA_EXPORT int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
     return 1;
 }
 
-MODELICA_EXPORT double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
+double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
                                  _In_z_ const char* tableName,
                                  _Out_ size_t* m, _Out_ size_t* n,
                                  int verbose) {

--- a/Modelica/Resources/C-Sources/ModelicaIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaIO.h
@@ -25,12 +25,14 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Definition of interface to external functions for array I/O
-   in the Modelica Standard Library:
+/* The following #define's are available.
 
-      Modelica.Utilities.Streams.readMatrixSize
-      Modelica.Utilities.Streams.readRealMatrix
-      Modelica.Utilities.Streams.writeRealMatrix
+   NO_FILE_SYSTEM : A file system is not present (e.g. on dSPACE or xPC).
+   NO_LOCALE      : locale.h is not present (e.g. on AVR).
+   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
+                    Useful definition:
+                    - "__declspec(dllexport)" if included in a DLL and the
+                      functions shall be visible outside of the DLL
 
    Release Notes:
       Mar. 08, 2017: by Thomas Beutlich, ESI ITI GmbH
@@ -41,11 +43,25 @@
                      Implemented a first version (ticket #1856)
 */
 
-#if !defined(MODELICAIO_H)
-#define MODELICAIO_H
+#ifndef MODELICA_IO_H_
+#define MODELICA_IO_H_
 
 #include <stdlib.h>
 
+#if !defined(MODELICA_EXPORT)
+#if defined(__cplusplus)
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
+#endif
+
+/*
+ * Non-null pointers and esp. null-terminated strings need to be passed to
+ * external functions.
+ *
+ * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
+ */
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #else
@@ -58,7 +74,7 @@
 #define _Out_
 #endif
 
-void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
+MODELICA_EXPORT void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
                                 _In_z_ const char* matrixName,
                                 _Out_ int* dim) MODELICA_NONNULLATTR;
   /* Read matrix dimensions from file
@@ -68,7 +84,7 @@ void ModelicaIO_readMatrixSizes(_In_z_ const char* fileName,
      -> dim: Output array for number of rows and columns
   */
 
-void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
+MODELICA_EXPORT void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
                                _Out_ double* matrix, size_t m, size_t n,
                                int verbose) MODELICA_NONNULLATTR;
@@ -82,7 +98,7 @@ void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
      -> verbose: Print message that file is loading
   */
 
-int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
+MODELICA_EXPORT int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
                                _In_ double* matrix, size_t m, size_t n,
                                int append,
@@ -104,7 +120,7 @@ int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
                  = "7.3": MATLAB MAT-file of version 7.3
   */
 
-double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
+MODELICA_EXPORT double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
                                  _In_z_ const char* tableName,
                                  _Out_ size_t* m, _Out_ size_t* n,
                                  int verbose) MODELICA_NONNULLATTR;

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -25,29 +25,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* The functions in this file are mostly non-portable. The following #define's
-   are used to define the system calls of the operating system
-
-   _WIN32         : System calls of Windows'95, Windows'NT
-                    (Note, that these system calls allow both '/' and '\'
-                    as directory separator for input arguments. As return
-                    argument '\' is used).
-                    All system calls are from the library libc.a.
-   _POSIX_        : System calls of POSIX
-   _MSC_VER       : Microsoft Visual C++
-   __GNUC__       : GNU C compiler
-   NO_FILE_SYSTEM : A file system is not present (e.g. on dSPACE or xPC).
-   NO_PID         : Function getpid is not present (e.g. on dSPACE)
-   NO_TIME        : Function gettimeofday is not present (e.g. on dSPACE)
-   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
-                    Useful definitions:
-                    - "static" that is all functions become static
-                      (useful if file is included with other C-sources for an
-                       embedded system)
-                    - "__declspec(dllexport)" if included in a DLL and the
-                      functions shall be visible outside of the DLL
-
-   Release Notes:
+/* Release Notes:
       Mar. 27, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Replaced localtime by re-entrant function
 
@@ -122,10 +100,7 @@
                      ModelicaInternal_getFullPath
 */
 
-#if !defined(MODELICA_EXPORT)
-  #define MODELICA_EXPORT
-#endif
-
+#include "ModelicaInternal.h"
 #include <string.h>
 #include "ModelicaUtilities.h"
 
@@ -139,32 +114,6 @@
   #define _POSIX_ 1
 #endif
 
-/*
- * Non-null pointers and esp. null-terminated strings need to be passed to
- * external functions.
- *
- * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
- */
-#if defined(__GNUC__)
-#define MODELICA_NONNULLATTR __attribute__((nonnull))
-#if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
-#define MODELICA_RETURNNONNULLATTR __attribute__((returns_nonnull))
-#else
-#define MODELICA_RETURNNONNULLATTR
-#endif
-#elif defined(__ATTR_SAL)
-#define MODELICA_NONNULLATTR
-#define MODELICA_RETURNNONNULLATTR _Ret_z_ /* _Ret_notnull_ and null-terminated */
-#else
-#define MODELICA_NONNULLATTR
-#define MODELICA_RETURNNONNULLATTR
-#endif
-#if !defined(__ATTR_SAL)
-#define _In_z_
-#define _Out_
-#define _Ret_z_
-#endif
-
 static void ModelicaNotExistError(const char* name) {
   /* Print error message if a function is not implemented */
     ModelicaFormatError("C-Function \"%s\" is called\n"
@@ -174,54 +123,54 @@ static void ModelicaNotExistError(const char* name) {
 }
 
 #ifdef NO_FILE_SYSTEM
-MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_mkdir(_In_z_ const char* directoryName) {
     ModelicaNotExistError("ModelicaInternal_mkdir"); }
-MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_rmdir(_In_z_ const char* directoryName) {
     ModelicaNotExistError("ModelicaInternal_rmdir"); }
-MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) {
+int ModelicaInternal_stat(_In_z_ const char* name) {
     ModelicaNotExistError("ModelicaInternal_stat"); return 0; }
-MODELICA_EXPORT void ModelicaInternal_rename(_In_z_ const char* oldName,
+void ModelicaInternal_rename(_In_z_ const char* oldName,
     _In_z_ const char* newName) {
     ModelicaNotExistError("ModelicaInternal_rename"); }
-MODELICA_EXPORT void ModelicaInternal_removeFile(_In_z_ const char* file) {
+void ModelicaInternal_removeFile(_In_z_ const char* file) {
     ModelicaNotExistError("ModelicaInternal_removeFile"); }
-MODELICA_EXPORT void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
+void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
     _In_z_ const char* newFile) {
     ModelicaNotExistError("ModelicaInternal_copyFile"); }
-MODELICA_EXPORT void ModelicaInternal_readDirectory(_In_z_ const char* directory,
+void ModelicaInternal_readDirectory(_In_z_ const char* directory,
     int nFiles, _Out_ const char** files) {
     ModelicaNotExistError("ModelicaInternal_readDirectory"); }
-MODELICA_EXPORT int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) {
+int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) {
     ModelicaNotExistError("ModelicaInternal_getNumberOfFiles"); return 0; }
-MODELICA_EXPORT const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
+const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
     ModelicaNotExistError("ModelicaInternal_fullPathName"); return NULL; }
-MODELICA_EXPORT const char* ModelicaInternal_temporaryFileName(void) {
+const char* ModelicaInternal_temporaryFileName(void) {
     ModelicaNotExistError("ModelicaInternal_temporaryFileName"); return NULL; }
-MODELICA_EXPORT void ModelicaStreams_closeFile(_In_z_ const char* fileName) {
+void ModelicaStreams_closeFile(_In_z_ const char* fileName) {
     ModelicaNotExistError("ModelicaStreams_closeFile"); }
-MODELICA_EXPORT void ModelicaInternal_print(_In_z_ const char* string,
+void ModelicaInternal_print(_In_z_ const char* string,
     _In_z_ const char* fileName) {
     if ( fileName[0] == '\0' ) {
       /* Write string to terminal */
         ModelicaFormatMessage("%s\n", string);
     }
     return; }
-MODELICA_EXPORT int ModelicaInternal_countLines(_In_z_ const char* fileName) {
+int ModelicaInternal_countLines(_In_z_ const char* fileName) {
     ModelicaNotExistError("ModelicaInternal_countLines"); return 0; }
-MODELICA_EXPORT void ModelicaInternal_readFile(_In_z_ const char* fileName,
+void ModelicaInternal_readFile(_In_z_ const char* fileName,
     _Out_ const char** string, size_t nLines) {
     ModelicaNotExistError("ModelicaInternal_readFile"); }
-MODELICA_EXPORT const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
+const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
     int lineNumber, _Out_ int* endOfFile) {
     ModelicaNotExistError("ModelicaInternal_readLine"); return NULL; }
-MODELICA_EXPORT void ModelicaInternal_chdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_chdir(_In_z_ const char* directoryName) {
     ModelicaNotExistError("ModelicaInternal_chdir"); }
-MODELICA_EXPORT const char* ModelicaInternal_getcwd(int dummy) {
+const char* ModelicaInternal_getcwd(int dummy) {
     ModelicaNotExistError("ModelicaInternal_getcwd"); return NULL; }
-MODELICA_EXPORT void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
+void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
     _Out_ const char** content, _Out_ int* exist) {
     ModelicaNotExistError("ModelicaInternal_getenv"); }
-MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
+void ModelicaInternal_setenv(_In_z_ const char* name,
     _In_z_ const char* value, int convertFromSlash) {
     ModelicaNotExistError("ModelicaInternal_setenv"); }
 #else
@@ -260,38 +209,6 @@ MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
   #include <sys/types.h>
   #include <sys/stat.h>
 #endif
-
-MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_rename(_In_z_ const char* oldName,
-    _In_z_ const char* newName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_removeFile(_In_z_ const char* file) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
-    _In_z_ const char* newFile) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
-    _Out_ const char** files) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) MODELICA_NONNULLATTR;
-MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_fullPathName(
-    _In_z_ const char* name) MODELICA_NONNULLATTR;
-MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_temporaryFileName(void);
-MODELICA_EXPORT void ModelicaStreams_closeFile(_In_z_ const char* fileName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_print(_In_z_ const char* string,
-    _In_z_ const char* fileName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaInternal_countLines(_In_z_ const char* fileName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_readFile(_In_z_ const char* fileName,
-    _Out_ const char** string, size_t nLines) MODELICA_NONNULLATTR;
-MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
-    int lineNumber, _Out_ int* endOfFile) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_chdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
-MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_getcwd(int dummy);
-MODELICA_EXPORT void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
-    _Out_ const char** content, _Out_ int* exist) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
-    _In_z_ const char* value, int convertFromSlash) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaInternal_getTime(_Out_ int* ms, _Out_ int* sec, _Out_ int* min, _Out_ int* hour,
-    _Out_ int* mday, _Out_ int* mon, _Out_ int* year) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaInternal_getpid(void);
 
 #if PATH_MAX > 1024
 #define BUFFER_LENGTH PATH_MAX
@@ -336,7 +253,7 @@ static void ModelicaConvertFromUnixDirectorySeparator(char* string) {
 
 /* --------------------- Modelica_Utilities.Internal --------------------------------- */
 
-MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_mkdir(_In_z_ const char* directoryName) {
     /* Create directory */
 #if defined(__WATCOMC__) || defined(__LCC__)
     int result = mkdir(directoryName);
@@ -355,7 +272,7 @@ MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) {
 #endif
 }
 
-MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_rmdir(_In_z_ const char* directoryName) {
     /* Remove directory */
 #if defined(__WATCOMC__) || defined(__LCC__) || defined(_POSIX_) || defined(__GNUC__)
     int result = rmdir(directoryName);
@@ -372,7 +289,7 @@ MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) {
 #endif
 }
 
-MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) {
+int ModelicaInternal_stat(_In_z_ const char* name) {
     /* Inquire type of file */
     ModelicaFileType type = FileType_NoFile;
 #if defined(_WIN32)
@@ -441,7 +358,7 @@ MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) {
     return type;
 }
 
-MODELICA_EXPORT void ModelicaInternal_rename(_In_z_ const char* oldName,
+void ModelicaInternal_rename(_In_z_ const char* oldName,
                              _In_z_ const char* newName) {
     /* Change the name of a file or of a directory */
     if ( rename(oldName, newName) != 0 ) {
@@ -450,7 +367,7 @@ MODELICA_EXPORT void ModelicaInternal_rename(_In_z_ const char* oldName,
     }
 }
 
-MODELICA_EXPORT void ModelicaInternal_removeFile(_In_z_ const char* file) {
+void ModelicaInternal_removeFile(_In_z_ const char* file) {
     /* Remove file */
     if ( remove(file) != 0 ) {
         ModelicaFormatError("Not possible to remove file \"%s\":\n%s",
@@ -458,7 +375,7 @@ MODELICA_EXPORT void ModelicaInternal_removeFile(_In_z_ const char* file) {
     }
 }
 
-MODELICA_EXPORT void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
+void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
                                _In_z_ const char* newFile) {
     /* Copy file */
 #ifdef _WIN32
@@ -515,7 +432,7 @@ MODELICA_EXPORT void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
     fclose(fpNew);
 }
 
-MODELICA_EXPORT void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
+void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
                                     _Out_ const char** files) {
     /* Get all file and directory names in a directory in any order
        (must be very careful, to call closedir if an error occurs)
@@ -593,7 +510,7 @@ MODELICA_EXPORT void ModelicaInternal_readDirectory(_In_z_ const char* directory
 #endif
 }
 
-MODELICA_EXPORT int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) {
+int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) {
     /* Get number of files and directories in a directory */
 #if defined(__WATCOMC__) || defined(__BORLANDC__) || defined(_WIN32) || defined(_POSIX_) || defined(__GNUC__)
     int nFiles = 0;
@@ -633,7 +550,7 @@ Modelica_ERROR:
 
 /* --------------------- Modelica_Utilities.Files ------------------------------------- */
 
-MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
+_Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
     /* Get full path name of file or directory */
 
 #if defined(_WIN32) || (_BSD_SOURCE || _XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED || (_POSIX_VERSION >= 200112L))
@@ -677,7 +594,7 @@ MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const c
     return fullName;
 }
 
-MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_temporaryFileName(void) {
+_Ret_z_ const char* ModelicaInternal_temporaryFileName(void) {
     /* Get full path name of a temporary */
     char* fullName;
 
@@ -859,7 +776,7 @@ static FILE* ModelicaStreams_openFileForReading(const char* fileName, int line) 
     return fp;
 }
 
-MODELICA_EXPORT void ModelicaStreams_closeFile(_In_z_ const char* fileName) {
+void ModelicaStreams_closeFile(_In_z_ const char* fileName) {
     /* Close file */
     CloseCachedFile(fileName); /* Closes it */
 }
@@ -886,7 +803,7 @@ static FILE* ModelicaStreams_openFileForWriting(const char* fileName) {
 
 /* --------------------- Modelica_Utilities.Streams ----------------------------------- */
 
-MODELICA_EXPORT void ModelicaInternal_print(_In_z_ const char* string,
+void ModelicaInternal_print(_In_z_ const char* string,
                             _In_z_ const char* fileName) {
     /* Write string to terminal or to file */
     if ( fileName[0] == '\0' ) {
@@ -912,7 +829,7 @@ Modelica_ERROR2:
     }
 }
 
-MODELICA_EXPORT int ModelicaInternal_countLines(_In_z_ const char* fileName) {
+int ModelicaInternal_countLines(_In_z_ const char* fileName) {
     /* Get number of lines of a file */
     int c;
     int nLines = 0;
@@ -935,7 +852,7 @@ MODELICA_EXPORT int ModelicaInternal_countLines(_In_z_ const char* fileName) {
     return nLines;
 }
 
-MODELICA_EXPORT void ModelicaInternal_readFile(_In_z_ const char* fileName,
+void ModelicaInternal_readFile(_In_z_ const char* fileName,
                                _Out_ const char** string, size_t nLines) {
     /* Read file into string vector string[nLines] */
     FILE* fp = ModelicaStreams_openFileForReading(fileName, 0);
@@ -997,7 +914,7 @@ MODELICA_EXPORT void ModelicaInternal_readFile(_In_z_ const char* fileName,
     fclose(fp);
 }
 
-MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
+_Ret_z_ const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
                                       int lineNumber, _Out_ int* endOfFile) {
     /* Read line lineNumber from file fileName */
     FILE* fp = ModelicaStreams_openFileForReading(fileName, lineNumber - 1);
@@ -1072,7 +989,7 @@ Modelica_ERROR3:
 
 /* --------------------- Modelica_Utilities.System ------------------------------------ */
 
-MODELICA_EXPORT void ModelicaInternal_chdir(_In_z_ const char* directoryName) {
+void ModelicaInternal_chdir(_In_z_ const char* directoryName) {
     /* Change current working directory */
 #if defined(__WATCOMC__) || defined(__LCC__)
     int result = chdir(directoryName);
@@ -1093,7 +1010,7 @@ MODELICA_EXPORT void ModelicaInternal_chdir(_In_z_ const char* directoryName) {
 #endif
 }
 
-MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_getcwd(int dummy) {
+_Ret_z_ const char* ModelicaInternal_getcwd(int dummy) {
     const char* cwd;
     char* directory;
 
@@ -1120,7 +1037,7 @@ MODELICA_EXPORT _Ret_z_ const char* ModelicaInternal_getcwd(int dummy) {
     return directory;
 }
 
-MODELICA_EXPORT void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
+void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
                              _Out_ const char** content, _Out_ int* exist) {
     /* Get content of environment variable */
     char* result;
@@ -1166,7 +1083,7 @@ MODELICA_EXPORT void ModelicaInternal_getenv(_In_z_ const char* name, int conver
     *content = result;
 }
 
-MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
+void ModelicaInternal_setenv(_In_z_ const char* name,
                              _In_z_ const char* value, int convertFromSlash) {
 #if defined(__WATCOMC__) || defined(__BORLANDC__) || defined(_WIN32) || defined(_POSIX_) || defined(__GNUC__)
     char localbuf[BUFFER_LENGTH];
@@ -1229,7 +1146,7 @@ MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
   #endif
 #endif
 
-MODELICA_EXPORT int ModelicaInternal_getpid(void) {
+int ModelicaInternal_getpid(void) {
 #if defined(NO_PID)
     return 0;
 #else
@@ -1241,7 +1158,7 @@ MODELICA_EXPORT int ModelicaInternal_getpid(void) {
 #endif
 }
 
-MODELICA_EXPORT void ModelicaInternal_getTime(_Out_ int* ms, _Out_ int* sec, _Out_ int* min, _Out_ int* hour,
+void ModelicaInternal_getTime(_Out_ int* ms, _Out_ int* sec, _Out_ int* min, _Out_ int* hour,
                               _Out_ int* mday, _Out_ int* mon, _Out_ int* year) {
 #if defined(NO_TIME)
     *ms   = 0;

--- a/Modelica/Resources/C-Sources/ModelicaInternal.h
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.h
@@ -1,0 +1,110 @@
+/* ModelicaInternal.h - External functions header for Modelica.Utilities
+
+   Copyright (C) 2002-2017, Modelica Association and DLR
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The following #define's are available.
+
+   NO_FILE_SYSTEM : A file system is not present (e.g. on dSPACE or xPC).
+   NO_PID         : Function getpid is not present (e.g. on dSPACE)
+   NO_TIME        : Function gettimeofday is not present (e.g. on dSPACE)
+   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
+                    Useful definition:
+                    - "__declspec(dllexport)" if included in a DLL and the
+                      functions shall be visible outside of the DLL
+*/
+
+#ifndef MODELICA_INTERNAL_H_
+#define MODELICA_INTERNAL_H_
+
+#include <stdlib.h>
+
+#if !defined(MODELICA_EXPORT)
+#if defined(__cplusplus)
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
+#endif
+
+/*
+ * Non-null pointers and esp. null-terminated strings need to be passed to
+ * external functions.
+ *
+ * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
+ */
+#if defined(__GNUC__)
+#define MODELICA_NONNULLATTR __attribute__((nonnull))
+#if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
+#define MODELICA_RETURNNONNULLATTR __attribute__((returns_nonnull))
+#else
+#define MODELICA_RETURNNONNULLATTR
+#endif
+#elif defined(__ATTR_SAL)
+#define MODELICA_NONNULLATTR
+#define MODELICA_RETURNNONNULLATTR _Ret_z_ /* _Ret_notnull_ and null-terminated */
+#else
+#define MODELICA_NONNULLATTR
+#define MODELICA_RETURNNONNULLATTR
+#endif
+#if !defined(__ATTR_SAL)
+#define _In_z_
+#define _Out_
+#define _Ret_z_
+#endif
+
+MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_rename(_In_z_ const char* oldName,
+    _In_z_ const char* newName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_removeFile(_In_z_ const char* file) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
+    _In_z_ const char* newFile) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
+    _Out_ const char** files) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaInternal_getNumberOfFiles(_In_z_ const char* directory) MODELICA_NONNULLATTR;
+MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_fullPathName(
+    _In_z_ const char* name) MODELICA_NONNULLATTR;
+MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_temporaryFileName(void);
+MODELICA_EXPORT void ModelicaStreams_closeFile(_In_z_ const char* fileName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_print(_In_z_ const char* string,
+    _In_z_ const char* fileName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaInternal_countLines(_In_z_ const char* fileName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_readFile(_In_z_ const char* fileName,
+    _Out_ const char** string, size_t nLines) MODELICA_NONNULLATTR;
+MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
+    int lineNumber, _Out_ int* endOfFile) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_chdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
+MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaInternal_getcwd(int dummy);
+MODELICA_EXPORT void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
+    _Out_ const char** content, _Out_ int* exist) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_setenv(_In_z_ const char* name,
+    _In_z_ const char* value, int convertFromSlash) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaInternal_getTime(_Out_ int* ms, _Out_ int* sec, _Out_ int* min, _Out_ int* hour,
+    _Out_ int* mday, _Out_ int* mon, _Out_ int* year) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaInternal_getpid(void);
+
+#endif

--- a/Modelica/Resources/C-Sources/ModelicaMatIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.c
@@ -26,8 +26,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
-   This file was created by concatenation of the following C source files of the
+/* This file was created by concatenation of the following C source files of the
    MAT file I/O library from <http://sourceforge.net/projects/matio/>:
 
    endian.c
@@ -43,8 +42,7 @@
    matvar_struct.c
 */
 
-/*
-   By default v4 and v6 MAT-files are supported. The v7 and v7.3 MAT-file
+/* By default v4 and v6 MAT-files are supported. The v7 and v7.3 MAT-file
    formats require additional preprocessor options and third-party libraries.
    The following #define's are available.
 
@@ -56,7 +54,6 @@
                    The hdf5 (>= v1.8) library is required.
 */
 
-#include "ModelicaUtilities.h"
 #if !defined(NO_FILE_SYSTEM)
 #if defined(__gnu_linux__)
 #define _GNU_SOURCE 1
@@ -64,6 +61,7 @@
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
 #include <stdarg.h>
+#include "ModelicaUtilities.h"
 
 /* -------------------------------
  * ---------- endian.c

--- a/Modelica/Resources/C-Sources/ModelicaMatIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.h
@@ -34,8 +34,8 @@
    matio_pubconf.h
 */
 
-#ifndef MODELICAMATIO_H
-#define MODELICAMATIO_H
+#ifndef MODELICA_MATIO_H_
+#define MODELICA_MATIO_H_
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -129,9 +129,9 @@ typedef uint8_t mat_uint8_t;
 #include <stdarg.h>
 
 #if defined(__cplusplus)
-#define EXTERN extern "C"
+#define MATIO_EXTERN extern "C"
 #else
-#define EXTERN
+#define MATIO_EXTERN
 #endif
 
 /** @defgroup MAT Matlab MAT File I/O Library */
@@ -311,81 +311,81 @@ typedef struct mat_sparse_t {
 } mat_sparse_t;
 
 /* Library function */
-EXTERN void Mat_GetLibraryVersion(int *major,int *minor,int *release);
+MATIO_EXTERN void Mat_GetLibraryVersion(int *major,int *minor,int *release);
 
 /* io.c */
-EXTERN char  *strdup_vprintf(const char *format, va_list ap);
-EXTERN char  *strdup_printf(const char *format, ...);
-EXTERN void   Mat_Critical( const char *format, ... );
-EXTERN void   Mat_Warning( const char *format, ... );
-EXTERN size_t Mat_SizeOf(enum matio_types data_type);
-EXTERN size_t Mat_SizeOfClass(int class_type);
+MATIO_EXTERN char  *strdup_vprintf(const char *format, va_list ap);
+MATIO_EXTERN char  *strdup_printf(const char *format, ...);
+MATIO_EXTERN void   Mat_Critical( const char *format, ... );
+MATIO_EXTERN void   Mat_Warning( const char *format, ... );
+MATIO_EXTERN size_t Mat_SizeOf(enum matio_types data_type);
+MATIO_EXTERN size_t Mat_SizeOfClass(int class_type);
 
 /* MAT File functions */
-#define            Mat_Create(a,b) Mat_CreateVer(a,b,MAT_FT_DEFAULT)
-EXTERN mat_t      *Mat_CreateVer(const char *matname,const char *hdr_str,
-                       enum mat_ft mat_file_ver);
-EXTERN int         Mat_Close(mat_t *mat);
-EXTERN mat_t      *Mat_Open(const char *matname,int mode);
-EXTERN const char *Mat_GetFilename(mat_t *mat);
-EXTERN enum mat_ft Mat_GetVersion(mat_t *mat);
-EXTERN char      **Mat_GetDir(mat_t *mat, size_t *n);
-EXTERN int         Mat_Rewind(mat_t *mat);
+#define                  Mat_Create(a,b) Mat_CreateVer(a,b,MAT_FT_DEFAULT)
+MATIO_EXTERN mat_t      *Mat_CreateVer(const char *matname,const char *hdr_str,
+                             enum mat_ft mat_file_ver);
+MATIO_EXTERN int         Mat_Close(mat_t *mat);
+MATIO_EXTERN mat_t      *Mat_Open(const char *matname,int mode);
+MATIO_EXTERN const char *Mat_GetFilename(mat_t *mat);
+MATIO_EXTERN enum mat_ft Mat_GetVersion(mat_t *mat);
+MATIO_EXTERN char      **Mat_GetDir(mat_t *mat, size_t *n);
+MATIO_EXTERN int         Mat_Rewind(mat_t *mat);
 
 /* MAT variable functions */
-EXTERN matvar_t  *Mat_VarCalloc(void);
-EXTERN matvar_t  *Mat_VarCreate(const char *name,enum matio_classes class_type,
-                      enum matio_types data_type,int rank,size_t *dims,
-                      void *data,int opt);
-EXTERN matvar_t  *Mat_VarCreateStruct(const char *name,int rank,size_t *dims,
-                      const char **fields,unsigned nfields);
-EXTERN int        Mat_VarDelete(mat_t *mat, const char *name);
-EXTERN matvar_t  *Mat_VarDuplicate(const matvar_t *in, int opt);
-EXTERN void       Mat_VarFree(matvar_t *matvar);
-EXTERN matvar_t  *Mat_VarGetCell(matvar_t *matvar,int index);
-EXTERN matvar_t **Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,
-                      int *edge);
-EXTERN matvar_t **Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,
-                      int edge);
-EXTERN size_t     Mat_VarGetSize(matvar_t *matvar);
-EXTERN unsigned   Mat_VarGetNumberOfFields(matvar_t *matvar);
-EXTERN int        Mat_VarAddStructField(matvar_t *matvar,const char *fieldname);
-EXTERN char * const *Mat_VarGetStructFieldnames(const matvar_t *matvar);
-EXTERN matvar_t  *Mat_VarGetStructFieldByIndex(matvar_t *matvar,
-                      size_t field_index,size_t index);
-EXTERN matvar_t  *Mat_VarGetStructFieldByName(matvar_t *matvar,
-                      const char *field_name,size_t index);
-EXTERN matvar_t  *Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,
-                      int opt,int index);
-EXTERN matvar_t  *Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,
-                      int *edge,int copy_fields);
-EXTERN matvar_t  *Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,
-                      int edge,int copy_fields);
-EXTERN void       Mat_VarPrint( matvar_t *matvar, int printdata );
-EXTERN matvar_t  *Mat_VarRead(mat_t *mat, const char *name );
-EXTERN int        Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
-                      int *start,int *stride,int *edge);
-EXTERN int        Mat_VarReadDataAll(mat_t *mat,matvar_t *matvar);
-EXTERN int        Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,
-                      int start,int stride,int edge);
-EXTERN matvar_t  *Mat_VarReadInfo( mat_t *mat, const char *name );
-EXTERN matvar_t  *Mat_VarReadNext( mat_t *mat );
-EXTERN matvar_t  *Mat_VarReadNextInfo( mat_t *mat );
-EXTERN matvar_t  *Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell);
-EXTERN matvar_t  *Mat_VarSetStructFieldByIndex(matvar_t *matvar,
-                      size_t field_index,size_t index,matvar_t *field);
-EXTERN matvar_t  *Mat_VarSetStructFieldByName(matvar_t *matvar,
-                      const char *field_name,size_t index,matvar_t *field);
-EXTERN int        Mat_VarWrite(mat_t *mat,matvar_t *matvar,
-                      enum matio_compression compress );
-EXTERN int        Mat_VarWriteInfo(mat_t *mat,matvar_t *matvar);
-EXTERN int        Mat_VarWriteData(mat_t *mat,matvar_t *matvar,void *data,
-                      int *start,int *stride,int *edge);
+MATIO_EXTERN matvar_t  *Mat_VarCalloc(void);
+MATIO_EXTERN matvar_t  *Mat_VarCreate(const char *name,enum matio_classes class_type,
+                            enum matio_types data_type,int rank,size_t *dims,
+                            void *data,int opt);
+MATIO_EXTERN matvar_t  *Mat_VarCreateStruct(const char *name,int rank,size_t *dims,
+                            const char **fields,unsigned nfields);
+MATIO_EXTERN int        Mat_VarDelete(mat_t *mat, const char *name);
+MATIO_EXTERN matvar_t  *Mat_VarDuplicate(const matvar_t *in, int opt);
+MATIO_EXTERN void       Mat_VarFree(matvar_t *matvar);
+MATIO_EXTERN matvar_t  *Mat_VarGetCell(matvar_t *matvar,int index);
+MATIO_EXTERN matvar_t **Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,
+                            int *edge);
+MATIO_EXTERN matvar_t **Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,
+                            int edge);
+MATIO_EXTERN size_t     Mat_VarGetSize(matvar_t *matvar);
+MATIO_EXTERN unsigned   Mat_VarGetNumberOfFields(matvar_t *matvar);
+MATIO_EXTERN int        Mat_VarAddStructField(matvar_t *matvar,const char *fieldname);
+MATIO_EXTERN char * const *Mat_VarGetStructFieldnames(const matvar_t *matvar);
+MATIO_EXTERN matvar_t  *Mat_VarGetStructFieldByIndex(matvar_t *matvar,
+                            size_t field_index,size_t index);
+MATIO_EXTERN matvar_t  *Mat_VarGetStructFieldByName(matvar_t *matvar,
+                            const char *field_name,size_t index);
+MATIO_EXTERN matvar_t  *Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,
+                            int opt,int index);
+MATIO_EXTERN matvar_t  *Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,
+                            int *edge,int copy_fields);
+MATIO_EXTERN matvar_t  *Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,
+                            int edge,int copy_fields);
+MATIO_EXTERN void       Mat_VarPrint( matvar_t *matvar, int printdata );
+MATIO_EXTERN matvar_t  *Mat_VarRead(mat_t *mat, const char *name );
+MATIO_EXTERN int        Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
+                            int *start,int *stride,int *edge);
+MATIO_EXTERN int        Mat_VarReadDataAll(mat_t *mat,matvar_t *matvar);
+MATIO_EXTERN int        Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,
+                            int start,int stride,int edge);
+MATIO_EXTERN matvar_t  *Mat_VarReadInfo( mat_t *mat, const char *name );
+MATIO_EXTERN matvar_t  *Mat_VarReadNext( mat_t *mat );
+MATIO_EXTERN matvar_t  *Mat_VarReadNextInfo( mat_t *mat );
+MATIO_EXTERN matvar_t  *Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell);
+MATIO_EXTERN matvar_t  *Mat_VarSetStructFieldByIndex(matvar_t *matvar,
+                            size_t field_index,size_t index,matvar_t *field);
+MATIO_EXTERN matvar_t  *Mat_VarSetStructFieldByName(matvar_t *matvar,
+                            const char *field_name,size_t index,matvar_t *field);
+MATIO_EXTERN int        Mat_VarWrite(mat_t *mat,matvar_t *matvar,
+                            enum matio_compression compress );
+MATIO_EXTERN int        Mat_VarWriteInfo(mat_t *mat,matvar_t *matvar);
+MATIO_EXTERN int        Mat_VarWriteData(mat_t *mat,matvar_t *matvar,void *data,
+                            int *start,int *stride,int *edge);
 
 /* Other functions */
-EXTERN int     Mat_CalcSingleSubscript(int rank,int *dims,int *subs);
-EXTERN int     Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index);
-EXTERN int    *Mat_CalcSubscripts(int rank,int *dims,int index);
-EXTERN size_t *Mat_CalcSubscripts2(int rank,size_t *dims,size_t index);
+MATIO_EXTERN int     Mat_CalcSingleSubscript(int rank,int *dims,int *subs);
+MATIO_EXTERN int     Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index);
+MATIO_EXTERN int    *Mat_CalcSubscripts(int rank,int *dims,int index);
+MATIO_EXTERN size_t *Mat_CalcSubscripts2(int rank,size_t *dims,size_t index);
 
 #endif /* MODELICAMATIO_H */

--- a/Modelica/Resources/C-Sources/ModelicaRandom.h
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.h
@@ -1,0 +1,77 @@
+/* ModelicaRandom.h - External functions header for Modelica.Math.Random library
+
+   Copyright (C) 2015-2017, Modelica Association and DLR
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The following #define's are available.
+
+   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
+                    Useful definition:
+                    - "__declspec(dllexport)" if included in a DLL and the
+                      functions shall be visible outside of the DLL
+*/
+
+#ifndef MODELICA_RANDOM_H_
+#define MODELICA_RANDOM_H_
+
+#include <stdlib.h>
+
+#if !defined(MODELICA_EXPORT)
+#if defined(__cplusplus)
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
+#endif
+
+/*
+ * Non-null pointers need to be passed to external functions.
+ *
+ * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
+ */
+#if defined(__GNUC__)
+#define MODELICA_NONNULLATTR __attribute__((nonnull))
+#else
+#define MODELICA_NONNULLATTR
+#endif
+#if !defined(__ATTR_SAL)
+#define _In_
+#define _Out_
+#endif
+
+MODELICA_EXPORT void ModelicaRandom_xorshift64star(_In_ int* state_in,
+    _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaRandom_xorshift128plus(_In_ int* state_in,
+    _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaRandom_xorshift1024star(_In_ int* state_in,
+    _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaRandom_setInternalState_xorshift1024star(
+    _In_ int* state, size_t nState, int id) MODELICA_NONNULLATTR;
+MODELICA_EXPORT double ModelicaRandom_impureRandom_xorshift1024star(int id);
+MODELICA_EXPORT int ModelicaRandom_automaticGlobalSeed(double dummy);
+MODELICA_EXPORT void ModelicaRandom_convertRealToIntegers(double d,
+    _Out_ int* i) MODELICA_NONNULLATTR;
+
+#endif

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -33,18 +33,6 @@
       Modelica.Blocks.Tables.CombiTable1Ds
       Modelica.Blocks.Tables.CombiTable2D
 
-   The following #define's are available.
-
-   NO_FILE_SYSTEM        : A file system is not present (e.g. on dSPACE or xPC).
-   DEBUG_TIME_EVENTS     : Trace time events of CombiTimeTable
-   DUMMY_FUNCTION_USERTAB: Use a dummy function "usertab"
-   NO_TABLE_COPY         : Do not copy table data passed to _init functions
-                           This is a potentially unsafe optimization (ticket #1143).
-   TABLE_SHARE           : If NO_FILE_SYTEM is not defined then common/shared table
-                           arrays are stored in a global hash table in order to
-                           avoid superfluous file input access and to decrease the
-                           utilized memory (tickets #1110 and #1550).
-
    Release Notes:
       Mar. 08, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Moved file I/O functions to ModelicaIO (ticket #2192)
@@ -722,7 +710,7 @@ void ModelicaStandardTables_CombiTimeTable_close(void* _tableID) {
         if (tableID->table != NULL && tableID->source == TABLESOURCE_FILE) {
 #if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             if (tableID->tableName != NULL && tableID->fileName != NULL) {
-                char* key = malloc((strlen(tableID->tableName) +
+                char* key = (char*)malloc((strlen(tableID->tableName) +
                     strlen(tableID->fileName) + 2)*sizeof(char));
                 if (key != NULL) {
                     TableShare *iter;
@@ -1890,7 +1878,7 @@ void ModelicaStandardTables_CombiTable1D_close(void* _tableID) {
         if (tableID->table != NULL && tableID->source == TABLESOURCE_FILE) {
 #if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             if (tableID->tableName != NULL && tableID->fileName != NULL) {
-                char* key = malloc((strlen(tableID->tableName) +
+                char* key = (char*)malloc((strlen(tableID->tableName) +
                     strlen(tableID->fileName) + 2)*sizeof(char));
                 if (key != NULL) {
                     TableShare *iter;
@@ -2461,7 +2449,7 @@ void ModelicaStandardTables_CombiTable2D_close(void* _tableID) {
         if (tableID->table != NULL && tableID->source == TABLESOURCE_FILE) {
 #if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             if (tableID->tableName != NULL && tableID->fileName != NULL) {
-                char* key = malloc((strlen(tableID->tableName) +
+                char* key = (char*)malloc((strlen(tableID->tableName) +
                     strlen(tableID->fileName) + 2)*sizeof(char));
                 if (key != NULL) {
                     TableShare *iter;
@@ -4308,7 +4296,7 @@ static double* readTable(_In_z_ const char* tableName, _In_z_ const char* fileNa
     double* table = NULL;
     if (tableName != NULL && fileName != NULL && nRow != NULL && nCol != NULL) {
 #if defined(TABLE_SHARE)
-        char* key = malloc((strlen(tableName) +
+        char* key = (char*)malloc((strlen(tableName) +
             strlen(fileName) + 2)*sizeof(char));
         if (key != NULL) {
             int updateError = 0;
@@ -4339,7 +4327,7 @@ static double* readTable(_In_z_ const char* tableName, _In_z_ const char* fileNa
             }
             if (iter == NULL) {
                 /* Share miss -> Insert new table */
-                iter = malloc(sizeof(TableShare));
+                iter = (TableShare*)malloc(sizeof(TableShare));
                 if (iter != NULL) {
                     iter->key = key;
                     iter->refCount = 1;

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.h
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.h
@@ -26,13 +26,17 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Definition of interface to external functions for table computation
-   in the Modelica Standard Library:
+/* The following #define's are available.
 
-      Modelica.Blocks.Sources.CombiTimeTable
-      Modelica.Blocks.Tables.CombiTable1D
-      Modelica.Blocks.Tables.CombiTable1Ds
-      Modelica.Blocks.Tables.CombiTable2D
+   NO_FILE_SYSTEM        : A file system is not present (e.g. on dSPACE or xPC).
+   NO_TABLE_COPY         : Do not copy table data passed to _init functions
+                           This is a potentially unsafe optimization (ticket #1143).
+   TABLE_SHARE           : If NO_FILE_SYTEM is not defined then common/shared table
+                           arrays are stored in a global hash table in order to
+                           avoid superfluous file input access and to decrease the
+                           utilized memory (tickets #1110 and #1550).
+   DEBUG_TIME_EVENTS     : Trace time events of CombiTimeTable
+   DUMMY_FUNCTION_USERTAB: Use a dummy function "usertab"
 
    Release Notes:
       Feb. 25, 2017: by Thomas Beutlich, ESI ITI GmbH
@@ -65,12 +69,17 @@
    slope approximation (univariate only) are used.
 */
 
-#ifndef _MODELICASTANDARDTABLES_H_
-#define _MODELICASTANDARDTABLES_H_
+#ifndef MODELICA_STANDARDTABLES_H_
+#define MODELICA_STANDARDTABLES_H_
 
 #include <stdlib.h>
+
+#if !defined(MODELICA_EXPORT)
 #if defined(__cplusplus)
-extern "C" {
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
 #endif
 
 /*
@@ -90,7 +99,7 @@ extern "C" {
 #define _Inout_
 #endif
 
-void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
+MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
                                                  _In_z_ const char* fileName,
                                                  _In_ double* table, size_t nRow,
                                                  size_t nColumn,
@@ -127,10 +136,10 @@ void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
      <- RETURN: Pointer to internal memory of table structure
   */
 
-void ModelicaStandardTables_CombiTimeTable_close(void* tableID);
+MODELICA_EXPORT void ModelicaStandardTables_CombiTimeTable_close(void* tableID);
   /* Close table and free allocated memory */
 
-double ModelicaStandardTables_CombiTimeTable_read(void* tableID, int force,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_read(void* tableID, int force,
                                                   int verbose);
   /* Read table from file
 
@@ -140,13 +149,13 @@ double ModelicaStandardTables_CombiTimeTable_read(void* tableID, int force,
      <- RETURN: = 1, if table was successfully read from file
   */
 
-double ModelicaStandardTables_CombiTimeTable_minimumTime(void* tableID);
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_minimumTime(void* tableID);
   /* Return minimum abscissa defined in table (= table[1,1]) */
 
-double ModelicaStandardTables_CombiTimeTable_maximumTime(void* tableID);
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_maximumTime(void* tableID);
   /* Return maximum abscissa defined in table (= table[end,1]) */
 
-double ModelicaStandardTables_CombiTimeTable_getValue(void* tableID,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_getValue(void* tableID,
                                                       int icol, double t,
                                                       double nextTimeEvent,
                                                       double preNextTimeEvent);
@@ -160,7 +169,7 @@ double ModelicaStandardTables_CombiTimeTable_getValue(void* tableID,
      <- RETURN : Ordinate value
   */
 
-double ModelicaStandardTables_CombiTimeTable_getDerValue(void* tableID,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_getDerValue(void* tableID,
                                                          int icol,
                                                          double t,
                                                          double nextTimeEvent,
@@ -177,7 +186,7 @@ double ModelicaStandardTables_CombiTimeTable_getDerValue(void* tableID,
      <- RETURN: Derivative of ordinate value
   */
 
-double ModelicaStandardTables_CombiTimeTable_nextTimeEvent(void* tableID, double t);
+MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_nextTimeEvent(void* tableID, double t);
   /* Return next time event in table
 
      -> tableID: Pointer to table defined with ModelicaStandardTables_CombiTimeTable_init
@@ -185,7 +194,7 @@ double ModelicaStandardTables_CombiTimeTable_nextTimeEvent(void* tableID, double
      <- RETURN: Next abscissa value > t that triggers a time event
   */
 
-void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
+MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
                                                _In_ double* table, size_t nRow,
                                                size_t nColumn,
@@ -193,7 +202,7 @@ void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
                                                size_t nCols, int smoothness) MODELICA_NONNULLATTR;
   /* Same as ModelicaStandardTables_CombiTable1D_init2, but without extrapolation argument */
 
-void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* tableName,
+MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* tableName,
                                                 _In_z_ const char* fileName,
                                                 _In_ double* table, size_t nRow,
                                                 size_t nColumn,
@@ -230,10 +239,10 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* tableName,
      <- RETURN: Pointer to internal memory of table structure
   */
 
-void ModelicaStandardTables_CombiTable1D_close(void* tableID);
+MODELICA_EXPORT void ModelicaStandardTables_CombiTable1D_close(void* tableID);
   /* Close table and free allocated memory */
 
-double ModelicaStandardTables_CombiTable1D_read(void* tableID, int force,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_read(void* tableID, int force,
                                                 int verbose);
   /* Read table from file
 
@@ -243,13 +252,13 @@ double ModelicaStandardTables_CombiTable1D_read(void* tableID, int force,
      <- RETURN: = 1, if table was successfully read from file
   */
 
-double ModelicaStandardTables_CombiTable1D_minimumAbscissa(void* tableID);
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_minimumAbscissa(void* tableID);
   /* Return minimum abscissa defined in table (= table[1,1]) */
 
-double ModelicaStandardTables_CombiTable1D_maximumAbscissa(void* tableID);
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_maximumAbscissa(void* tableID);
   /* Return maximum abscissa defined in table (= table[end,1]) */
 
-double ModelicaStandardTables_CombiTable1D_getValue(void* tableID, int icol,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_getValue(void* tableID, int icol,
                                                     double u);
   /* Interpolate in table
 
@@ -259,7 +268,7 @@ double ModelicaStandardTables_CombiTable1D_getValue(void* tableID, int icol,
      <- RETURN : Ordinate value
   */
 
-double ModelicaStandardTables_CombiTable1D_getDerValue(void* tableID, int icol,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_getDerValue(void* tableID, int icol,
                                                        double u, double der_u);
   /* Interpolated derivative in table
 
@@ -270,7 +279,7 @@ double ModelicaStandardTables_CombiTable1D_getDerValue(void* tableID, int icol,
      <- RETURN: Derivative of ordinate value
   */
 
-void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
+MODELICA_EXPORT void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
                                                _In_ double* table, size_t nRow,
                                                size_t nColumn, int smoothness) MODELICA_NONNULLATTR;
@@ -296,10 +305,10 @@ void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
      <- RETURN: Pointer to internal memory of table structure
   */
 
-void ModelicaStandardTables_CombiTable2D_close(void* tableID);
+MODELICA_EXPORT void ModelicaStandardTables_CombiTable2D_close(void* tableID);
   /* Close table and free allocated memory */
 
-double ModelicaStandardTables_CombiTable2D_read(void* tableID, int force,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable2D_read(void* tableID, int force,
                                                 int verbose);
   /* Read table from file
 
@@ -309,7 +318,7 @@ double ModelicaStandardTables_CombiTable2D_read(void* tableID, int force,
      <- RETURN: = 1, if table was successfully read from file
   */
 
-double ModelicaStandardTables_CombiTable2D_getValue(void* tableID, double u1,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable2D_getValue(void* tableID, double u1,
                                                     double u2);
   /* Interpolate in table
 
@@ -319,7 +328,7 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* tableID, double u1,
      <- RETURN : Interpolated value
   */
 
-double ModelicaStandardTables_CombiTable2D_getDerValue(void* tableID, double u1,
+MODELICA_EXPORT double ModelicaStandardTables_CombiTable2D_getDerValue(void* tableID, double u1,
                                                        double u2, double der_u1,
                                                        double der_u2);
   /* Interpolated derivative in table
@@ -332,8 +341,4 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* tableID, double u1,
      <- RETURN: Derivative of interpolated value
   */
 
-#if defined(__cplusplus)
-}
 #endif
-
-#endif /* _MODELICASTANDARDTABLES_H_ */

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -25,21 +25,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* The functions are mostly non-portable. The following #define's are used
-   to define the system calls of the operating system
-
-   _MSC_VER       : Microsoft Visual C++
-   __GNUC__       : GNU C compiler
-   NO_LOCALE      : locale.h is not present (e.g. on AVR).
-   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
-                    Useful definitions:
-                    - "static" that is all functions become static
-                      (useful if file is included with other C-sources for an
-                       embedded system)
-                    - "__declspec(dllexport)" if included in a DLL and the
-                      functions shall be visible outside of the DLL
-
-   Release Notes:
+/* Release Notes:
       Nov. 23, 2016: by Martin Sjölund, SICS East Swedish ICT AB
                      Added NO_LOCALE define flag, in case the OS does
                      not have this (for example when using GCC compiler,
@@ -80,64 +66,21 @@
                      Implemented a first version
 */
 
-#if !defined(MODELICA_EXPORT)
-#   define MODELICA_EXPORT
-#endif
 #if defined(__gnu_linux__)
 #define _GNU_SOURCE 1
 #endif
 
-#include "ModelicaUtilities.h"
+#include "ModelicaStrings.h"
+
 #include <ctype.h>
-#include <stdlib.h>
 #include <string.h>
 #if !defined(NO_LOCALE)
 #include <locale.h>
 #endif
 
-/*
- * Non-null pointers and esp. null-terminated strings need to be passed to
- * external functions.
- *
- * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
- */
-#if defined(__GNUC__)
-#define MODELICA_NONNULLATTR __attribute__((nonnull))
-#if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
-#define MODELICA_RETURNNONNULLATTR __attribute__((returns_nonnull))
-#else
-#define MODELICA_RETURNNONNULLATTR
-#endif
-#elif defined(__ATTR_SAL)
-#define MODELICA_NONNULLATTR
-#define MODELICA_RETURNNONNULLATTR _Ret_z_ /* _Ret_notnull_ and null-terminated */
-#else
-#define MODELICA_NONNULLATTR
-#define MODELICA_RETURNNONNULLATTR
-#endif
-#if !defined(__ATTR_SAL)
-#define _In_z_
-#define _Out_
-#define _Ret_z_
-#endif
+#include "ModelicaUtilities.h"
 
-MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaStrings_substring(
-    _In_z_ const char* string, int startIndex, int endIndex) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaStrings_length(_In_z_ const char* string) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaStrings_skipWhiteSpace(_In_z_ const char* string,
-    int i) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
-    int startIndex, _Out_ int* nextIndex, _Out_ const char** identifier) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaStrings_scanInteger(_In_z_ const char* string,
-    int startIndex, int unsignedNumber, _Out_ int* nextIndex,
-    _Out_ int* integerNumber) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaStrings_scanReal(_In_z_ const char* string, int startIndex,
-    int unsignedNumber, _Out_ int* nextIndex, _Out_ double* number) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
-    _Out_ int* nextIndex, _Out_ const char** result) MODELICA_NONNULLATTR;
-MODELICA_EXPORT int ModelicaStrings_hashString(_In_z_ const char* str) MODELICA_NONNULLATTR;
-
-MODELICA_EXPORT _Ret_z_ const char* ModelicaStrings_substring(_In_z_ const char* string,
+_Ret_z_ const char* ModelicaStrings_substring(_In_z_ const char* string,
                                       int startIndex, int endIndex) {
     /* Return string1(startIndex:endIndex) if endIndex >= startIndex,
        or return string1(startIndex:startIndex), if endIndex = 0.
@@ -176,12 +119,12 @@ MODELICA_EXPORT _Ret_z_ const char* ModelicaStrings_substring(_In_z_ const char*
     return substring;
 }
 
-MODELICA_EXPORT int ModelicaStrings_length(_In_z_ const char* string) {
+int ModelicaStrings_length(_In_z_ const char* string) {
     /* Return the number of characters "string" */
     return (int) strlen(string);
 }
 
-MODELICA_EXPORT int ModelicaStrings_compare(const char* string1, const char* string2, int caseSensitive) {
+int ModelicaStrings_compare(const char* string1, const char* string2, int caseSensitive) {
     /* Compare two strings, optionally ignoring case */
     int result;
     if (string1 == 0 || string2 == 0) {
@@ -213,7 +156,7 @@ MODELICA_EXPORT int ModelicaStrings_compare(const char* string1, const char* str
 
 #define MAX_TOKEN_SIZE 100
 
-MODELICA_EXPORT int ModelicaStrings_skipWhiteSpace(_In_z_ const char* string, int i) {
+int ModelicaStrings_skipWhiteSpace(_In_z_ const char* string, int i) {
     /* Return index in string after skipping ws, or position of terminating nul. */
     while (string[i-1] != '\0' && isspace((unsigned char)string[i-1])) {
         ++i;
@@ -282,7 +225,7 @@ static int MatchUnsignedInteger(const char* string, int start) {
 
 /* --------------- end of utility functions used in scanXXX functions ----------- */
 
-MODELICA_EXPORT void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
+void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
                                     int startIndex, _Out_ int* nextIndex,
                                     _Out_ const char** identifier) {
     int token_start = ModelicaStrings_skipWhiteSpace(string, startIndex);
@@ -314,7 +257,7 @@ MODELICA_EXPORT void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
     return;
 }
 
-MODELICA_EXPORT void ModelicaStrings_scanInteger(_In_z_ const char* string,
+void ModelicaStrings_scanInteger(_In_z_ const char* string,
                                  int startIndex, int unsignedNumber,
                                  _Out_ int* nextIndex, _Out_ int* integerNumber) {
     int sign = 0;
@@ -380,7 +323,7 @@ MODELICA_EXPORT void ModelicaStrings_scanInteger(_In_z_ const char* string,
     return;
 }
 
-MODELICA_EXPORT void ModelicaStrings_scanReal(_In_z_ const char* string, int startIndex,
+void ModelicaStrings_scanReal(_In_z_ const char* string, int startIndex,
                               int unsignedNumber, _Out_ int* nextIndex,
                               _Out_ double* number) {
     /*
@@ -502,7 +445,7 @@ Modelica_ERROR:
     return;
 }
 
-MODELICA_EXPORT void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
+void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
                                 _Out_ int* nextIndex, _Out_ const char** result) {
     int i, token_start, past_token, token_length;
 
@@ -546,7 +489,7 @@ Modelica_ERROR:
     return;
 }
 
-MODELICA_EXPORT int ModelicaStrings_hashString(_In_z_ const char* inStr) {
+int ModelicaStrings_hashString(_In_z_ const char* inStr) {
     /* Compute an unsigned int hash code from a character string
      *
      * Author: Arash Partow - 2002                                            *

--- a/Modelica/Resources/C-Sources/ModelicaStrings.h
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.h
@@ -1,0 +1,93 @@
+/* ModelicaStrings.h - External functions header for Modelica.Functions.Strings
+
+   Copyright (C) 2002-2017, Modelica Association and DLR
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The functions are mostly non-portable. The following #define's are used
+   to define the system calls of the operating system
+
+   NO_LOCALE      : locale.h is not present (e.g. on AVR).
+   MODELICA_EXPORT: Prefix used for function calls. If not defined, blank is used
+                    Useful definition:
+                    - "__declspec(dllexport)" if included in a DLL and the
+                      functions shall be visible outside of the DLL
+*/
+
+#ifndef MODELICA_STRINGS_H_
+#define MODELICA_STRINGS_H_
+
+#include <stdlib.h>
+
+#if !defined(MODELICA_EXPORT)
+#if defined(__cplusplus)
+#define MODELICA_EXPORT extern "C"
+#else
+#define MODELICA_EXPORT
+#endif
+#endif
+
+/*
+ * Non-null pointers and esp. null-terminated strings need to be passed to
+ * external functions.
+ *
+ * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
+ */
+#if defined(__GNUC__)
+#define MODELICA_NONNULLATTR __attribute__((nonnull))
+#if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
+#define MODELICA_RETURNNONNULLATTR __attribute__((returns_nonnull))
+#else
+#define MODELICA_RETURNNONNULLATTR
+#endif
+#elif defined(__ATTR_SAL)
+#define MODELICA_NONNULLATTR
+#define MODELICA_RETURNNONNULLATTR _Ret_z_ /* _Ret_notnull_ and null-terminated */
+#else
+#define MODELICA_NONNULLATTR
+#define MODELICA_RETURNNONNULLATTR
+#endif
+#if !defined(__ATTR_SAL)
+#define _In_z_
+#define _Out_
+#define _Ret_z_
+#endif
+
+MODELICA_EXPORT MODELICA_RETURNNONNULLATTR const char* ModelicaStrings_substring(
+    _In_z_ const char* string, int startIndex, int endIndex) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaStrings_length(_In_z_ const char* string) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaStrings_skipWhiteSpace(_In_z_ const char* string,
+    int i) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
+    int startIndex, _Out_ int* nextIndex, _Out_ const char** identifier) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaStrings_scanInteger(_In_z_ const char* string,
+    int startIndex, int unsignedNumber, _Out_ int* nextIndex,
+    _Out_ int* integerNumber) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaStrings_scanReal(_In_z_ const char* string, int startIndex,
+    int unsignedNumber, _Out_ int* nextIndex, _Out_ double* number) MODELICA_NONNULLATTR;
+MODELICA_EXPORT void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
+    _Out_ int* nextIndex, _Out_ const char** result) MODELICA_NONNULLATTR;
+MODELICA_EXPORT int ModelicaStrings_hashString(_In_z_ const char* str) MODELICA_NONNULLATTR;
+
+#endif

--- a/Modelica/Resources/C-Sources/ModelicaUtilities.h
+++ b/Modelica/Resources/C-Sources/ModelicaUtilities.h
@@ -37,11 +37,12 @@
    this header file is shipped with the Modelica Standard Library.
 */
 
-#ifndef MODELICA_UTILITIES_H
-#define MODELICA_UTILITIES_H
+#ifndef MODELICA_UTILITIES_H_
+#define MODELICA_UTILITIES_H_
 
 #include <stddef.h>
 #include <stdarg.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
* Add headers for ModelicaExternalC sources
* Use MODELICA_EXPORT consistently (in header declaration only) and set it to `extern "C"` in case of C++
* Rename EXTERN to MATIO_EXTERN in ModelicaMatIO.h
* See #2008 and #2052 

@HansOlsson I kindly ask for your review (since you contributed in the above-mentioned tickets). Thank you!

One minor issue I see is that the static function linking is removed now. For that reason I also removed the respective comment on `MODELICA_EXPORT`. But since tool vendors need to provide libraries anyway, it should be fine this way.

@sjoelund FYI and testing with OMC. Thank you!