### PR TITLE
Fix argument order in ModelicaIO.c

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaIO.c
@@ -357,10 +357,10 @@ MODELICA_EXPORT double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
     }
 
     if (isMatExt == 1) {
-        table = readMatTable(fileName, tableName, m, n);
+        table = readMatTable(tableName, fileName, m, n);
     }
     else {
-        table = readTxtTable(fileName, tableName, m, n);
+        table = readTxtTable(tableName, fileName, m, n);
     }
     return table;
 }


### PR DESCRIPTION
The order of the arguments is wrong in the read*Table calls!