### PR TITLE
Generalize Multiplex/DeMultiplex for arbitrary number of connector signals

### DIFF
--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -172,6 +172,7 @@ Connector with one input signal of type Integer.
 Connector with one output signal of type Integer.
 </p>
 </html>"));
+
   connector RealVectorInput = input Real
     "Real input connector used for vector of connectors" annotation (
     defaultComponentName="u",
@@ -231,8 +232,8 @@ Integer input connector that is used for a vector of connectors,
 for example <a href=\"modelica://Modelica.Blocks.Interfaces.PartialIntegerMISO\">PartialIntegerMISO</a>,
 and has therefore a different icon as IntegerInput connector.
 </p>
-
 </html>"));
+
   connector BooleanVectorInput = input Boolean
     "Boolean input connector used for vector of connectors" annotation (
     defaultComponentName="u",
@@ -260,6 +261,36 @@ and has therefore a different icon as IntegerInput connector.
 Boolean input connector that is used for a vector of connectors,
 for example <a href=\"modelica://Modelica.Blocks.Interfaces.PartialBooleanMISO\">PartialBooleanMISO</a>,
 and has therefore a different icon as BooleanInput connector.
+</p>
+</html>"));
+
+  connector RealVectorOutput = output Real
+    "Real output connector used for vector of connectors" annotation (
+    defaultComponentName="y",
+    Icon(graphics={Ellipse(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,127},
+          fillColor={0,0,127},
+          fillPattern=FillPattern.Solid)}, coordinateSystem(
+        extent={{-100,-100},{100,100}},
+        preserveAspectRatio=true,
+        initialScale=0.2)),
+    Diagram(coordinateSystem(
+        preserveAspectRatio=false,
+        initialScale=0.2,
+        extent={{-100,-100},{100,100}}), graphics={Text(
+          extent={{-10,85},{-10,60}},
+          lineColor={0,0,127},
+          textString="%name"), Ellipse(
+          extent={{-50,50},{50,-50}},
+          lineColor={0,0,127},
+          fillColor={0,0,127},
+          fillPattern=FillPattern.Solid)}),
+    Documentation(info="<html>
+<p>
+Real output connector that is used for a vector of connectors,
+for example <a href=\"modelica://Modelica.Blocks.Routing.DeMultiplex\">DeMultiplex</a>,
+and has therefore a different icon as RealOutput connector.
 </p>
 </html>"));
 

--- a/Modelica/Blocks/Routing.mo
+++ b/Modelica/Blocks/Routing.mo
@@ -393,7 +393,7 @@ end Extractor;
 
   block Multiplex "Multiplexer block for arbitrary number of input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n(min=0)=0 "dimension of input signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
+    parameter Integer n(min=0)=0 "Dimension of input signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
     Modelica.Blocks.Interfaces.RealVectorInput u[n]
       "Connector of Real input signals" annotation(Placement(transformation(extent={{-120,70},{-80,-70}})));
     Modelica.Blocks.Interfaces.RealOutput y[n+0]
@@ -442,8 +442,8 @@ The output connector is the <strong>concatenation</strong> of the input connecto
 
   block Multiplex2 "Multiplexer block for two input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of input signal connector 1";
-    parameter Integer n2=1 "dimension of input signal connector 2";
+    parameter Integer n1=1 "Dimension of input signal connector 1";
+    parameter Integer n2=1 "Dimension of input signal connector 2";
     Modelica.Blocks.Interfaces.RealInput u1[n1]
       "Connector of Real input signals 1" annotation (Placement(transformation(
             extent={{-140,40},{-100,80}})));
@@ -489,9 +489,9 @@ explicitly defined via parameters n1 and n2.
 
   block Multiplex3 "Multiplexer block for three input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of input signal connector 1";
-    parameter Integer n2=1 "dimension of input signal connector 2";
-    parameter Integer n3=1 "dimension of input signal connector 3";
+    parameter Integer n1=1 "Dimension of input signal connector 1";
+    parameter Integer n2=1 "Dimension of input signal connector 2";
+    parameter Integer n3=1 "Dimension of input signal connector 3";
     Modelica.Blocks.Interfaces.RealInput u1[n1]
       "Connector of Real input signals 1" annotation (Placement(transformation(
             extent={{-140,50},{-100,90}})));
@@ -541,10 +541,10 @@ explicitly defined via parameters n1, n2 and n3.
 
   block Multiplex4 "Multiplexer block for four input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of input signal connector 1";
-    parameter Integer n2=1 "dimension of input signal connector 2";
-    parameter Integer n3=1 "dimension of input signal connector 3";
-    parameter Integer n4=1 "dimension of input signal connector 4";
+    parameter Integer n1=1 "Dimension of input signal connector 1";
+    parameter Integer n2=1 "Dimension of input signal connector 2";
+    parameter Integer n3=1 "Dimension of input signal connector 3";
+    parameter Integer n4=1 "Dimension of input signal connector 4";
     Modelica.Blocks.Interfaces.RealInput u1[n1]
       "Connector of Real input signals 1" annotation (Placement(transformation(
             extent={{-140,70},{-100,110}})));
@@ -600,11 +600,11 @@ explicitly defined via parameters n1, n2, n3 and n4.
 
   block Multiplex5 "Multiplexer block for five input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of input signal connector 1";
-    parameter Integer n2=1 "dimension of input signal connector 2";
-    parameter Integer n3=1 "dimension of input signal connector 3";
-    parameter Integer n4=1 "dimension of input signal connector 4";
-    parameter Integer n5=1 "dimension of input signal connector 5";
+    parameter Integer n1=1 "Dimension of input signal connector 1";
+    parameter Integer n2=1 "Dimension of input signal connector 2";
+    parameter Integer n3=1 "Dimension of input signal connector 3";
+    parameter Integer n4=1 "Dimension of input signal connector 4";
+    parameter Integer n5=1 "Dimension of input signal connector 5";
     Modelica.Blocks.Interfaces.RealInput u1[n1]
       "Connector of Real input signals 1" annotation (Placement(transformation(
             extent={{-140,80},{-100,120}})));
@@ -665,12 +665,12 @@ explicitly defined via parameters n1, n2, n3, n4 and n5.
 
   block Multiplex6 "Multiplexer block for six input connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of input signal connector 1";
-    parameter Integer n2=1 "dimension of input signal connector 2";
-    parameter Integer n3=1 "dimension of input signal connector 3";
-    parameter Integer n4=1 "dimension of input signal connector 4";
-    parameter Integer n5=1 "dimension of input signal connector 5";
-    parameter Integer n6=1 "dimension of input signal connector 6";
+    parameter Integer n1=1 "Dimension of input signal connector 1";
+    parameter Integer n2=1 "Dimension of input signal connector 2";
+    parameter Integer n3=1 "Dimension of input signal connector 3";
+    parameter Integer n4=1 "Dimension of input signal connector 4";
+    parameter Integer n5=1 "Dimension of input signal connector 5";
+    parameter Integer n6=1 "Dimension of input signal connector 6";
     Modelica.Blocks.Interfaces.RealInput u1[n1]
       "Connector of Real input signals 1" annotation (Placement(transformation(
             extent={{-124,73},{-100,97}})));
@@ -737,7 +737,7 @@ explicitly defined via parameters n1, n2, n3, n4, n5 and n6.
 
   block DeMultiplex "DeMultiplexer block for arbitrary number of output connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n(min=0)=0 "dimension of output signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
+    parameter Integer n(min=0)=0 "Dimension of output signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
     Modelica.Blocks.Interfaces.RealInput u[n+0]
       "Connector of Real input signals" annotation(Placement(transformation(extent={{-140,-20},{-100,20}})));
     Modelica.Blocks.Interfaces.RealVectorOutput y[n]
@@ -786,8 +786,8 @@ The input connector is <strong>split</strong> up into output connectors.
 
   block DeMultiplex2 "DeMultiplexer block for two output connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of output signal connector 1";
-    parameter Integer n2=1 "dimension of output signal connector 2";
+    parameter Integer n1=1 "Dimension of output signal connector 1";
+    parameter Integer n2=1 "Dimension of output signal connector 2";
     Modelica.Blocks.Interfaces.RealInput u[n1 + n2]
       "Connector of Real input signals" annotation (Placement(transformation(
             extent={{-140,-20},{-100,20}})));
@@ -834,9 +834,9 @@ explicitly defined via parameters n1 and n2.
 
   block DeMultiplex3 "DeMultiplexer block for three output connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of output signal connector 1";
-    parameter Integer n2=1 "dimension of output signal connector 2";
-    parameter Integer n3=1 "dimension of output signal connector 3";
+    parameter Integer n1=1 "Dimension of output signal connector 1";
+    parameter Integer n2=1 "Dimension of output signal connector 2";
+    parameter Integer n3=1 "Dimension of output signal connector 3";
     Modelica.Blocks.Interfaces.RealInput u[n1 + n2 + n3]
       "Connector of Real input signals" annotation (Placement(transformation(
             extent={{-140,-20},{-100,20}})));
@@ -888,10 +888,10 @@ explicitly defined via parameters n1, n2 and n3.
   block DeMultiplex4 "DeMultiplexer block for four output connectors"
 
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of output signal connector 1";
-    parameter Integer n2=1 "dimension of output signal connector 2";
-    parameter Integer n3=1 "dimension of output signal connector 3";
-    parameter Integer n4=1 "dimension of output signal connector 4";
+    parameter Integer n1=1 "Dimension of output signal connector 1";
+    parameter Integer n2=1 "Dimension of output signal connector 2";
+    parameter Integer n3=1 "Dimension of output signal connector 3";
+    parameter Integer n4=1 "Dimension of output signal connector 4";
     Modelica.Blocks.Interfaces.RealInput u[n1 + n2 + n3 + n4]
       "Connector of Real input signals" annotation (Placement(transformation(
             extent={{-140,-20},{-100,20}})));
@@ -947,11 +947,11 @@ explicitly defined via parameters n1, n2, n3 and n4.
   block DeMultiplex5 "DeMultiplexer block for five output connectors"
 
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of output signal connector 1";
-    parameter Integer n2=1 "dimension of output signal connector 2";
-    parameter Integer n3=1 "dimension of output signal connector 3";
-    parameter Integer n4=1 "dimension of output signal connector 4";
-    parameter Integer n5=1 "dimension of output signal connector 5";
+    parameter Integer n1=1 "Dimension of output signal connector 1";
+    parameter Integer n2=1 "Dimension of output signal connector 2";
+    parameter Integer n3=1 "Dimension of output signal connector 3";
+    parameter Integer n4=1 "Dimension of output signal connector 4";
+    parameter Integer n5=1 "Dimension of output signal connector 5";
     Modelica.Blocks.Interfaces.RealInput u[n1 + n2 + n3 + n4 + n5]
       "Connector of Real input signals" annotation (Placement(transformation(
             extent={{-140,-20},{-100,20}})));
@@ -1011,12 +1011,12 @@ explicitly defined via parameters n1, n2, n3, n4 and n5.
 
   block DeMultiplex6 "DeMultiplexer block for six output connectors"
     extends Modelica.Blocks.Icons.Block;
-    parameter Integer n1=1 "dimension of output signal connector 1";
-    parameter Integer n2=1 "dimension of output signal connector 2";
-    parameter Integer n3=1 "dimension of output signal connector 3";
-    parameter Integer n4=1 "dimension of output signal connector 4";
-    parameter Integer n5=1 "dimension of output signal connector 5";
-    parameter Integer n6=1 "dimension of output signal connector 6";
+    parameter Integer n1=1 "Dimension of output signal connector 1";
+    parameter Integer n2=1 "Dimension of output signal connector 2";
+    parameter Integer n3=1 "Dimension of output signal connector 3";
+    parameter Integer n4=1 "Dimension of output signal connector 4";
+    parameter Integer n5=1 "Dimension of output signal connector 5";
+    parameter Integer n6=1 "Dimension of output signal connector 6";
     Modelica.Blocks.Interfaces.RealInput u[n1 + n2 + n3 + n4 + n5 + n6]
       "Connector of Real input signals" annotation (Placement(transformation(
             extent={{-140,-20},{-100,20}})));

--- a/Modelica/Blocks/Routing.mo
+++ b/Modelica/Blocks/Routing.mo
@@ -391,6 +391,55 @@ value of the additional u index:</p>
 </html>"));
 end Extractor;
 
+  block Multiplex "Multiplexer block for arbitrary number of input connectors"
+    extends Modelica.Blocks.Icons.Block;
+    parameter Integer n(min=0)=0 "dimension of input signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
+    Modelica.Blocks.Interfaces.RealVectorInput u[n]
+      "Connector of Real input signals" annotation(Placement(transformation(extent={{-120,70},{-80,-70}})));
+    Modelica.Blocks.Interfaces.RealOutput y[size(u,1)]
+      "Connector of Real output signals" annotation(Placement(transformation(extent={{100,-10},{120,10}})));
+
+    equation
+      y = u;
+    annotation(
+      defaultComponentName="mux",
+      Documentation(info="<html>
+<p>
+The output connector is the <strong>concatenation</strong> of the input connectors.
+</p>
+</html>"),
+      Icon(
+        coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}),
+        graphics={
+          Line(points={{8,0},{102,0}}, color={0,0,127}),
+          Line(points={{-100,70},{-60,70},{-4,6}}, color={0,0,127}),
+          Line(points={{-100,0},{-12,0}}, color={0,0,127}),
+          Line(points={{-100,-70},{-62,-70},{-4,-4}}, color={0,0,127}),
+          Ellipse(
+            extent={{-14,16},{16,-14}},
+            fillColor={0,0,127},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,127}),
+          Line(points={{-100,0},{-6,0}}, color={0,0,127}),
+          Text(
+            extent={{-140,-90},{150,-50}},
+            textString="n=%n")}),
+      Diagram(
+        coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}),
+        graphics={
+          Line(points={{8,0},{102,0}}, color={0,0,255}),
+          Ellipse(
+            extent={{-14,16},{16,-14}},
+            fillColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(points={{-100,0},{-6,0}},color={0,0,255})}));
+  end Multiplex;
+
   block Multiplex2 "Multiplexer block for two input connectors"
     extends Modelica.Blocks.Icons.Block;
     parameter Integer n1=1 "dimension of input signal connector 1";
@@ -685,6 +734,55 @@ explicitly defined via parameters n1, n2, n3, n4, n5 and n6.
           Line(points={{-101,17},{-60,17},{-9,2}}, color={0,0,255}),
           Line(points={{-100,-18},{-60,-18},{-11,-4}}, color={0,0,255})}));
   end Multiplex6;
+
+  block DeMultiplex "DeMultiplexer block for arbitrary number of output connectors"
+    extends Modelica.Blocks.Icons.Block;
+    parameter Integer n(min=0)=0 "dimension of output signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
+    Modelica.Blocks.Interfaces.RealInput u[size(y,1)]
+      "Connector of Real input signals" annotation(Placement(transformation(extent={{-140,-20},{-100,20}})));
+    Modelica.Blocks.Interfaces.RealVectorOutput y[n]
+      "Connector of Real output signals"annotation(Placement(transformation(extent={{80,70},{120,-70}})));
+
+    equation
+      y = u;
+    annotation(
+      defaultComponentName="demux",
+      Documentation(info="<html>
+<p>
+The input connector is <strong>split</strong> up into output connectors.
+</p>
+</html>"),
+      Icon(
+        coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}),
+        graphics={
+          Line(points={{8,0},{102,0}}, color={0,0,127}),
+          Ellipse(
+            extent={{-14,16},{16,-14}},
+            fillColor={0,0,127},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,127}),
+          Line(points={{-100,0},{-6,0}}, color={0,0,127}),
+          Line(points={{100,70},{60,70},{4,5}}, color={0,0,127}),
+          Line(points={{0,0},{101,0}}, color={0,0,127}),
+          Line(points={{100,-70},{61,-70},{5,-5}}, color={0,0,127}),
+          Text(
+            extent={{-140,-90},{150,-50}},
+            textString="n=%n")}),
+      Diagram(
+        coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}),
+        graphics={
+          Line(points={{8,0},{102,0}}, color={0,0,255}),
+          Ellipse(
+            extent={{-14,16},{16,-14}},
+            fillColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(points={{-100,0},{-6,0}},color={0,0,255})}));
+  end DeMultiplex;
 
   block DeMultiplex2 "DeMultiplexer block for two output connectors"
     extends Modelica.Blocks.Icons.Block;

--- a/Modelica/Blocks/Routing.mo
+++ b/Modelica/Blocks/Routing.mo
@@ -396,7 +396,7 @@ end Extractor;
     parameter Integer n(min=0)=0 "dimension of input signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
     Modelica.Blocks.Interfaces.RealVectorInput u[n]
       "Connector of Real input signals" annotation(Placement(transformation(extent={{-120,70},{-80,-70}})));
-    Modelica.Blocks.Interfaces.RealOutput y[size(u,1)]
+    Modelica.Blocks.Interfaces.RealOutput y[n+0]
       "Connector of Real output signals" annotation(Placement(transformation(extent={{100,-10},{120,10}})));
 
     equation
@@ -738,7 +738,7 @@ explicitly defined via parameters n1, n2, n3, n4, n5 and n6.
   block DeMultiplex "DeMultiplexer block for arbitrary number of output connectors"
     extends Modelica.Blocks.Icons.Block;
     parameter Integer n(min=0)=0 "dimension of output signal connector" annotation(Dialog(connectorSizing=true), HideResult=true);
-    Modelica.Blocks.Interfaces.RealInput u[size(y,1)]
+    Modelica.Blocks.Interfaces.RealInput u[n+0]
       "Connector of Real input signals" annotation(Placement(transformation(extent={{-140,-20},{-100,20}})));
     Modelica.Blocks.Interfaces.RealVectorOutput y[n]
       "Connector of Real output signals"annotation(Placement(transformation(extent={{80,70},{120,-70}})));

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -1464,4 +1464,70 @@ This shows the improvements in the numerics when balance=true is set.
       annotation (Line(points={{-15.1,0},{10.2,0}}, color={0,0,127}));
     annotation ( experiment(StopTime=3));
   end Hysteresis;
+
+  model MuxDemux "Test model for the Mux and Demux blocks"
+    extends Modelica.Icons.Example;
+    Modelica.Blocks.Sources.Clock clock annotation (Placement(
+          transformation(extent={{-100,-10},{-80,10}})));
+    Modelica.Blocks.Routing.Multiplex mux5(n=5) annotation (Placement(
+          transformation(extent={{-30,-10},{-10,10}})));
+    Modelica.Blocks.Routing.DeMultiplex demux5(n=5)
+      annotation (Placement(transformation(extent={{12,-10},{32,10}})));
+    Modelica.Blocks.Routing.Multiplex mux3(n=3) annotation (Placement(
+          transformation(extent={{-60,-30},{-40,-10}})));
+    Modelica.Blocks.Routing.Multiplex mux2(n=2) annotation (Placement(
+          transformation(extent={{-60,10},{-40,30}})));
+    Modelica.Blocks.Routing.DeMultiplex demux2(n=2)
+      annotation (Placement(transformation(extent={{60,20},{80,40}})));
+    Modelica.Blocks.Interfaces.RealOutput y1 annotation (Placement(
+          transformation(extent={{100,30},{120,50}})));
+    Modelica.Blocks.Interfaces.RealOutput y2 annotation (Placement(
+          transformation(extent={{100,10},{120,30}})));
+    Modelica.Blocks.Interfaces.RealOutput y3 annotation (Placement(
+          transformation(extent={{100,-30},{120,-10}})));
+    Modelica.Blocks.Interfaces.RealOutput y4 annotation (Placement(
+          transformation(extent={{100,-50},{120,-30}})));
+    Modelica.Blocks.Interfaces.RealOutput y5 annotation (Placement(
+          transformation(extent={{100,-70},{120,-50}})));
+    Modelica.Blocks.Routing.DeMultiplex demux3(n=3) annotation (
+        Placement(transformation(extent={{60,-50},{80,-30}})));
+  equation
+    connect(clock.y, mux2.u[1]) annotation (Line(points={{-79,0},{-70,0},
+            {-70,23.5},{-60,23.5}}, color={0,0,127}));
+    connect(clock.y, mux2.u[2]) annotation (Line(points={{-79,0},{-70,0},
+            {-70,16.5},{-60,16.5}}, color={0,0,127}));
+    connect(clock.y, mux3.u[1]) annotation (Line(points={{-79,0},{-70,
+            0},{-70,-15.3333},{-60,-15.3333}},
+                                            color={0,0,127}));
+    connect(clock.y, mux3.u[2]) annotation (Line(points={{-79,0},{-70,0},
+            {-70,-20},{-60,-20}}, color={0,0,127}));
+    connect(clock.y, mux3.u[3]) annotation (Line(points={{-79,0},{-70,
+            0},{-70,-24.6667},{-60,-24.6667}},
+                                            color={0,0,127}));
+    connect(mux2.y, mux5.u[1:2]) annotation (Line(points={{-39,20},{-34,
+            20},{-34,2.8},{-30,2.8}}, color={0,0,127}));
+    connect(mux3.y, mux5.u[3:5]) annotation (Line(points={{-39,-20},{-34,
+            -20},{-34,-5.6},{-30,-5.6}}, color={0,0,127}));
+    connect(mux5.y, demux5.u)
+      annotation (Line(points={{-9,0},{10,0}}, color={0,0,127}));
+    connect(demux2.y[1], y1) annotation (Line(points={{80,33.5},{91,33.5},
+            {91,40},{110,40}}, color={0,0,127}));
+    connect(demux2.y[2], y2) annotation (Line(points={{80,26.5},{92,26.5},
+            {92,20},{110,20}}, color={0,0,127}));
+    connect(demux2.u, demux5.y[1:2]) annotation (Line(points={{58,30},
+            {46,30},{46,4},{32,4},{32,2.8}},
+                                    color={0,0,127}));
+    connect(y3, demux3.y[1]) annotation (Line(points={{110,-20},{96,
+            -20},{96,-35.3333},{80,-35.3333}},
+                                          color={0,0,127}));
+    connect(y4, demux3.y[2]) annotation (Line(points={{110,-40},{96,-40},
+            {96,-40},{80,-40}}, color={0,0,127}));
+    connect(y5, demux3.y[3]) annotation (Line(points={{110,-60},{96,
+            -60},{96,-44.6667},{80,-44.6667}},
+                                          color={0,0,127}));
+    connect(demux3.u, demux5.y[3:5]) annotation (Line(points={{58,-40},
+            {46,-40},{46,-4},{32,-4},{32,-5.6},{32,-5.6}},
+                                          color={0,0,127}));
+    annotation (experiment(StopTime=2));
+  end MuxDemux;
 end Blocks;

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -699,7 +699,7 @@ they were not deleted yet.")}));
           transformation(extent={{0,0},{20,20}})));
     Modelica.Mechanics.Rotational.Sources.Move move(useSupport=false)
       annotation (Placement(transformation(extent={{20,40},{40,60}})));
-    Modelica.Blocks.Routing.Multiplex3 Multiplex3_1 annotation (Placement(
+    Modelica.Blocks.Routing.Multiplex Multiplex3_1(n=3) annotation (Placement(
           transformation(extent={{-56,40},{-36,60}})));
     Modelica.Blocks.Sources.Constant Constant1(k=1) annotation (Placement(
           transformation(extent={{-100,16},{-80,36}})));
@@ -720,11 +720,11 @@ they were not deleted yet.")}));
       annotation (Line(points={{40,50},{42,50},{42,20}}));
     connect(Multiplex3_1.y, move.u)
       annotation (Line(points={{-35,50},{18,50}}, color={0,0,127}));
-    connect(Constant1.y, Multiplex3_1.u3[1]) annotation (Line(points={{-79,26},
+    connect(Constant1.y, Multiplex3_1.u[3]) annotation (Line(points={{-79,26},
             {-74,26},{-74,43},{-58,43}}, color={0,0,127}));
-    connect(Constant2.y, Multiplex3_1.u1[1]) annotation (Line(points={{-79,80},
+    connect(Constant2.y, Multiplex3_1.u[1]) annotation (Line(points={{-79,80},
             {-74,80},{-74,57},{-58,57}}, color={0,0,127}));
-    connect(Constant2.y, Multiplex3_1.u2[1]) annotation (Line(points={{-79,80},
+    connect(Constant2.y, Multiplex3_1.u[2]) annotation (Line(points={{-79,80},
             {-74,80},{-74,50},{-58,50}}, color={0,0,127}));
     connect(Multiplex3_1.y, move1.u) annotation (Line(points={{-35,50},{-28,50},
             {-28,-30},{-22,-30}}, color={0,0,127}));


### PR DESCRIPTION
Similar as the MultiSum block the new Multiplex and DeMultiplex blocks feature an arbitrary number of connector signals, which is automatically updated by tools supporting the connectorSizing annotation.

Once this pull request gets merged, the Multiplex2, Multiplex3, Multiplex4, Multiplex5, Multiplex6, DeMultiplex2, DeMultiplex3, DeMultiplex4, DeMultiplex5, and DeMultiplex6 blocks could be declared obsolete. I will file an extra pull request for this later.

Credits go to @dietmarw for pointing to the connectorSizing annotation and the MultiSum block.