### PR TITLE
Utilize hash macros of uthash.h v2.0.2 for ModelicaStrings_hashString

### DIFF
--- a/ModelicaTest/Utilities.mo
+++ b/ModelicaTest/Utilities.mo
@@ -207,13 +207,10 @@ extends Modelica.Icons.ExamplesPackage;
 
     Strings.scanNoToken("  abc = 3;   ", 11);
 
-    /*
-  Streams.print("\n... Demonstrate how to compute a hash value from a string:");
-  hash1 :=Modelica.Utilities.Strings.hashString("this is a test");
-  hash2 :=Modelica.Utilities.Strings.hashString("Controller.noise1");
-  Streams.print("    hash1 = " + String(hash1));
-  Streams.print("    hash2 = " + String(hash2));
-  */
+    hash1 := Strings.hashString("this is a test");
+    assert(hash1 == 1827717433, "Strings.hashString 1 failed");
+    hash2 := Strings.hashString("Controller.noise1");
+    assert(hash2 == -1025762750, "Strings.hashString 2 failed");
 
     ok := true;
   end Strings;


### PR DESCRIPTION
Stand-alone test model for #2250:
```mo
model T2250
  function hashString "Create a hash value of a string"
    input String string "The string to create a hash from";
    output Integer hash "The hash value of string";
    external "C" hash = test_hashString(string) annotation(Include="
#include \"uthash.h\"
#undef uthash_fatal /* Ensure that nowhere in this file uses uthash_fatal by accident */
int test_hashString(const char* str) {
    /* Compute an unsigned int hash code from a character string */
    size_t len = strlen(str);
    union hash_tag {
        unsigned int iu;
        int          is;
    } h;

    HASH_VALUE(str, len, h.iu); /* Requires uthash v2.0.2 */

    return h.is;
}");
  end hashString;

  initial algorithm 
    Modelica.Utilities.Streams.print(String(hashString("String")));
end T2250;
```