### PR TITLE
UseTimeEventsInstead

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1738,7 +1738,7 @@ a flange according to a given acceleration.
     endTime = Tes;
 
     // report when axis is moving
-    motion_ref = time <= endTime;
+    motion_ref = time < endTime;
     for i in 1:nout loop
       moving[i] = if abs(q_begin[i] - q_end[i]) > eps then motion_ref else
         false;

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -2645,7 +2645,7 @@ This package contains the bus definitions needed for the
             rotation=270)));
       Sources.RealExpression realExpression(y=time) annotation (Placement(
             transformation(extent={{-6,0},{20,20}})));
-      Sources.BooleanExpression booleanExpression(y=time > 0.5) annotation (
+      Sources.BooleanExpression booleanExpression(y=time >= 0.5) annotation (
           Placement(transformation(extent={{-6,-30},{20,-10}})));
     equation
       connect(realExpression.y, subControlBus.myRealSignal) annotation (Line(

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -5834,7 +5834,7 @@ An overview of all available hysteresis and permanent magnet elements of the pac
         hmax=mat.Hsat;
 
       equation
-        init2 = time > 1.5*t1;
+        init2 = time >= 1.5*t1;
         init3 = edge(init2);
 
         der(x) = 0;
@@ -5874,7 +5874,7 @@ An overview of all available hysteresis and permanent magnet elements of the pac
         delDesc = (alpha < pre(bSav[1]));
         del = delAsc or delDesc or evInit;
 
-        init = (abs(alpha) >= pre(hmax)) and time>2*t1;
+        init = (abs(alpha) >= pre(hmax)) and time>=2*t1;
 
         evInit = init and not pre(init);
 

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2801,9 +2801,9 @@ points, e.g., when an isentropic reference state is computed.
 
     equation
       // Define specific enthalpy and specific entropy
-      h1 = if time < 0 then h_min else if time > 1 then h_max else h_min + time
+      h1 = if time < 0 then h_min else if time >= 1 then h_max else h_min + time
         /timeUnit*(h_max - h_min);
-      s1 = if time < 0 then s_min else if time > 1 then s_max else s_min + time
+      s1 = if time < 0 then s_min else if time >= 1 then s_max else s_min + time
         /timeUnit*(s_max - s_min);
 
       // Solve for temperature
@@ -2881,9 +2881,9 @@ points, e.g., when an isentropic reference state is computed.
 
     equation
       // Define specific enthalpy
-      h1 = if time < 0 then h_min else if time > 1 then h_max else h_min + time
+      h1 = if time < 0 then h_min else if time >= 1 then h_max else h_min + time
         /timeUnit*(h_max - h_min);
-      s1 = if time < 0 then s_min else if time > 1 then s_max else s_min + time
+      s1 = if time < 0 then s_min else if time >= 1 then s_max else s_min + time
         /timeUnit*(s_max - s_min);
 
       // Solve for temperature

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -940,7 +940,7 @@ package Examples
                 -160},{41,-140}})));
     TransitionWithSignal transition7 annotation (Placement(transformation(
               extent={{9,-134},{-11,-114}})));
-    Modelica.Blocks.Sources.BooleanExpression setCondition(y=time > 7)
+    Modelica.Blocks.Sources.BooleanExpression setCondition(y=time >= 7)
       annotation (Placement(transformation(extent={{-77,-160},{-19,-140}})));
     Transition transition4a(enableTimer=true, waitTime=1)
       annotation (Placement(
@@ -1054,7 +1054,7 @@ has a higher priority to fire as alternative.split[2]).
               extent={{10,-70},{-10,-50}})));
     Parallel Parallel1 annotation (Placement(transformation(extent={{-30,-40},{
                 36,40}})));
-    Modelica.Blocks.Sources.BooleanExpression setCondition(y=time > 7)
+    Modelica.Blocks.Sources.BooleanExpression setCondition(y=time >= 7)
       annotation (Placement(transformation(extent={{-40,-90},{-10,-70}})));
       inner StateGraphRoot stateGraphRoot
         annotation (Placement(transformation(extent={{-90,50},{-70,70}})));
@@ -1698,7 +1698,7 @@ buttons:
       Transition transition1(
         enableTimer=false,
         waitTime=0,
-        condition=time > 8)
+        condition=time >= 8)
         annotation (Placement(
               transformation(extent={{-60,20},{-40,40}})));
       Step initStep annotation (Placement(transformation(extent={{-140,-10},{
@@ -1712,7 +1712,7 @@ buttons:
                                            annotation (Placement(transformation(
                 extent={{-20,-45},{10,-15}})));
       Transition transition2(
-        condition=time > 4,
+        condition=time >= 4,
         enableTimer=false,
         waitTime=0)
         annotation (Placement(


### PR DESCRIPTION
According to Modelica Specification 3.4 section 8.5 the expressions `time >= discrete expression` and `time < discrete expression` may generate time-events.

I changed these models to use one of these variants allowing time-events - replacing `time > discrete expression` and `time <= discrete expression`, which generated state events - since I could not see a good reason for this. (For post-initialization work I could understand the use of `time > 0`, but not for these.)

The reason is both that it is more efficient for these models and that it encourages good style.