### PR TITLE
UseTimeEventsInsteadInModelicaTest

### DIFF
--- a/ModelicaTest/Fluid/TestPipesAndValves.mo
+++ b/ModelicaTest/Fluid/TestPipesAndValves.mo
@@ -90,12 +90,12 @@ extends Modelica.Icons.ExamplesPackage;
       annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
     discrete Modelica.SIunits.MassFlowRate m_flow_initial;
   equation
-    when time > 0.1 then
+    when time >= 0.1 then
       m_flow_initial = valve.port_a.m_flow;
     end when;
     if pipe.energyDynamics >= Modelica.Fluid.Types.Dynamics.SteadyStateInitial and
        pipe.massDynamics >= Modelica.Fluid.Types.Dynamics.SteadyStateInitial then
-      when time > 1 then
+      when time >= 1 then
         assert(abs(valve.port_a.m_flow - m_flow_initial) < 1e-3, "!!!THE SIMULATION DID NOT START IN STEADY-STATE!!!");
       end when;
     end if;
@@ -1403,12 +1403,12 @@ Simulation starts with both valves open. At t=1, valve 1 closes; between t=3 and
       annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
     discrete Modelica.SIunits.MassFlowRate m_flow_initial;
   equation
-    when time > 0.1 then
+    when time >= 0.1 then
       m_flow_initial = valve.port_a.m_flow;
     end when;
     if pipe.energyDynamics >= Modelica.Fluid.Types.Dynamics.SteadyStateInitial and
        pipe.massDynamics >= Modelica.Fluid.Types.Dynamics.SteadyStateInitial then
-      when time > 1 then
+      when time >= 1 then
         assert(abs(valve.port_a.m_flow - m_flow_initial) < 1e-3, "!!!THE SIMULATION DID NOT START IN STEADY-STATE!!!");
       end when;
     end if;

--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -90,22 +90,22 @@ package Media "Test models for Modelica.Media"
 
       // When iterating at the initial time the asserts below could be violated.
       // To avoid an error, the check is only performed shortly after initialization.
-      if time > t_min then
+      if time >= t_min then
         assert(err_T <= eps, "Error: abs(medium.T - T) > eps " + "(err_T = "
            + String(err_T) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
         assert(err_d <= eps, "Error: abs(medium.d - d) > eps " + "(err_d = " +
           String(err_d) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
         assert(err_u <= eps, "Error: abs(medium.u - u) > eps " + "(err_u = " +
           String(err_u) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
         assert(err_h_is <= eps_h_is,
           "Error: entropy not constant for isentropicEnthalpy " + "(err_h_is = "
            + String(err_h_is) + ", eps = " + String(eps_h_is) + ")");
@@ -232,22 +232,22 @@ package Media "Test models for Modelica.Media"
 
       // When iterating at the initial time the asserts below could be violated.
       // To avoid an error, the check is only performed shortly after initialization.
-      if time > t_min then
+      if time >= t_min then
         assert(err_T <= eps, "Error: abs(medium.T - T) > eps " + "(err_T = "
            + String(err_T) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
         assert(err_d <= eps, "Error: abs(medium.d - d) > eps " + "(err_d = " +
           String(err_d) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
         assert(err_u <= eps, "Error: abs(medium.u - u) > eps " + "(err_u = " +
           String(err_u) + ", eps = " + String(eps) + ")");
       end if;
 
-      if time > t_min then
+      if time >= t_min then
       assert(err_h_is <= eps_h_is,
         "Error: entropy not constant for isentropicEnthalpy " + "(err_h_is = "
          + String(err_h_is) + ", eps = " + String(eps_h_is) + ")");


### PR DESCRIPTION
Similarly as #2263 but now for the test-cases in ModelicaTest, specifically:
ModelicaTest.Fluid.TestPipesAndValves.DynamicPipeInitialization
ModelicaTest.Fluid.TestPipesAndValves.LumpedPipeInitialization
and several models in ModelicaTest.Media.TestAllProperties