### PR TITLE
Backward compatibility correction for CombiTable2D-external object

### DIFF
--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -209,7 +209,7 @@ initialization definition.
       input String fileName "File name";
       input Real table[:, :];
       input Modelica.Blocks.Types.Smoothness smoothness;
-      input Modelica.Blocks.Types.Extrapolation extrapolation;
+      input Modelica.Blocks.Types.Extrapolation extrapolation=Modelica.Blocks.Types.Extrapolation.LastTwoPoints;
       input Boolean verboseRead=true "= true: Print info message; = false: No info message";
       output ExternalCombiTable2D externalCombiTable2D;
     external"C" externalCombiTable2D = ModelicaStandardTables_CombiTable2D_init2(


### PR DESCRIPTION
I noticed that ModelicaTest.Tables.CombiTable2D.Test15 no longer checks.
This was caused by #1839 adding a new input to the constructor - I just added a default for that to restore it (there is a default for the model - I matched that). At first I considered changing the test-case instead, but: there are multiple test-cases with the same issue and it is possible that some users also use the constructor directly.

I have previously noticed that users sometimes use the C-functions directly; thus it might be best to at least rename the C-function when changing the arguments to detect that - and possibly keep the old one.