### PR TITLE
Introduce correctly spelled types and declare existing ones as obsolete

### DIFF
--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -267,7 +267,7 @@ Zeunerstra&szlig;e 38<br />
 
 <h4>Acknowledgements:</h4>
 <ul>
-<li>The development of this library was done within the European ITEA2 projects EUROSYSLIB and MODELISAR. </li>
+<li>The development of this library was done within the European ITEA2 projects EUROSYSLIB and MODELISAR.</li>
 <li>For his contribution we thank Mr. Jonathan Gerbet.</li>
 </ul>
 </html>"));
@@ -5554,10 +5554,10 @@ on the model behaviour.
 
     record ModelcardR "Record with technology parameters (.model)"
       extends Modelica.Icons.Record;
-     parameter SI.Conversions.NonSIunits.FirstOrderTemperaturCoefficient TC1 =        0.0
+     parameter SI.LinearTemperatureCoefficientResistance TC1 = 0.0
         "First order temperature coefficient";
-     parameter SI.Conversions.NonSIunits.SecondOrderTemperaturCoefficient TC2 =               0.0
-        "In Ohm/(deg C*deg C), Second2 order temperature coefficient";
+     parameter SI.QuadraticTemperatureCoefficientResistance TC2 = 0.0
+        "Second order temperature coefficient";
      parameter SI.Resistance RSH = -1e40 "Sheet resistance";
      parameter SI.Temp_C TNOM = -1e40
         "Parameter measurement temperature, default 27";
@@ -10484,10 +10484,8 @@ to the internal parameters (e.g., m_area). It also does the analysis of the IsGi
 
       record ResistorModelLineParams "Record for resistor model line parameters"
       extends Modelica.Icons.Record;
-          SI.Conversions.NonSIunits.FirstOrderTemperaturCoefficient
-          m_dTC1 "First order temp, coefficient";
-          SI.Conversions.NonSIunits.SecondOrderTemperaturCoefficient
-          m_dTC2 "Second order temp, coefficient";
+          SI.LinearTemperatureCoefficientResistance m_dTC1 "First order temperature coefficient";
+          SI.QuadraticTemperatureCoefficientResistance m_dTC2 "Second order temperature coefficient";
           SI.Resistance m_dRsh "Sheet resistance";
           Real m_dRshIsGiven;
           SI.Length m_dDefW "Default device width";

--- a/Modelica/SIunits.mo
+++ b/Modelica/SIunits.mo
@@ -306,10 +306,10 @@ end UsersGuide;
 
       type FirstOrderTemperaturCoefficient =
                               Real (final quantity="FirstOrderTemperatureCoefficient",
-            final unit="Ohm/degC") "First Order Temperature Coefficient" annotation(absoluteValue=true);
+            final unit="Ohm/degC") "Obsolete type, use LinearTemperatureCoefficientResistance instead!" annotation(absoluteValue=true);
       type SecondOrderTemperaturCoefficient =
                               Real (final quantity="SecondOrderTemperatureCoefficient",
-            final unit="Ohm/degC2") "Second Order Temperature Coefficient" annotation(absoluteValue=true);
+            final unit="Ohm/degC2") "Obsolete type, use QuadraticTemperatureCoefficientResistance instead!" annotation(absoluteValue=true);
       type Area_cm =   Real (final quantity="Area", final unit="cm2")
         "Area in cm";
       type PerArea_cm =Real (final quantity="PerArea", final unit="1/cm2")
@@ -1264,6 +1264,12 @@ argument):</p>
   type ApparentPower = Real (final quantity="Power", final unit="VA");
   type ReactivePower = Real (final quantity="Power", final unit="var");
   type PowerFactor = Real (final quantity="PowerFactor", final unit="1");
+  type LinearTemperatureCoefficientResistance = Real (
+    final quantity="LinearTemperatureCoefficientResistance",
+    final unit="Ohm/K") "First Order Temperature Coefficient";
+  type QuadraticTemperatureCoefficientResistance = Real (
+    final quantity="QuadraticTemperatureCoefficientResistance",
+    final unit="Ohm/K2") "Second Order Temperature Coefficient";
 
   // added to ISO-chapter 5
   type Transconductance = Real (final quantity="Transconductance", final unit=


### PR DESCRIPTION
See #2284: Introduce correctly spelled types ''FirstOrderTemperatureCoefficient'' and ''SecondOrderTemperatureCoefficient'' in a backwards-compatible way.