### PR TITLE
make FluidConstants in PartialTwoPhaseMedium replaceable

### DIFF
--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -5773,7 +5773,7 @@ to the above list of assumptions</li>
 
   partial package PartialTwoPhaseMedium
     "Base class for two phase medium of one substance"
-    extends PartialPureSubstance(redeclare record FluidConstants =
+    extends PartialPureSubstance(redeclare replaceable record FluidConstants =
           Modelica.Media.Interfaces.Types.TwoPhase.FluidConstants);
     constant Boolean smoothModel=false
       "True if the (derived) model should not generate state events";


### PR DESCRIPTION
This is the change as suggested in #2286.

Non-partial media packages extending from `Interfaces.PartialTwoPhaseMedium` would then be able to redeclare `FluidConstants`.