### PR TITLE
Removes note about an old MSL dependency

### DIFF
--- a/Modelica/Fluid/Dissipation.mo
+++ b/Modelica/Fluid/Dissipation.mo
@@ -13034,18 +13034,22 @@ annotation (Documentation(info="<html>
 
 <h4>  Library description </h4>
 
+<p>
 This library contains <strong>convective heat transfer</strong> and  <strong>pressure loss</strong> functions written in
-Modelica&reg;. Generally the pressure loss calculations are based on incompressible fluids and total pressure difference. For devices with non changing cross sectional area, the calculated total pressure loss is equal to the static pressure difference. Geodetic pressure loss is not considered throughout the library. The functions supplied may be used separately.<br>
-<br>
-The library is a non-commercial product of XRG Simulation GmbH. It makes use of external,
-non-commercial models supplied by Modelica Standard Library. In order to work correctly,
-ensure that this library is always loaded with <strong> Modelica Standard Library version
-3.1</strong> especially to be able to use Modelica.Fluid applications.<br>
+Modelica&reg;. Generally the pressure loss calculations are based on incompressible fluids and total pressure difference. For devices with non changing cross sectional area, the calculated total pressure loss is equal to the static pressure difference. Geodetic pressure loss is not considered throughout the library. The functions supplied may be used separately.
+</p>
+
+<p>
+The library is a non-commercial product of XRG Simulation GmbH.
+</p>
 
 <h4>  Acknowledgements </h4>
+
+<p>
 The following people contributed to the Fluid.Dissipation library (alphabetical list):
 J&ouml;rg Eiden, Ole Engel, Nina Peci, Sven Rutkowski, Thorben Vahlenkamp, Stefan
 Wischhusen.
+</p>
 
 <p>
 The development of the Fluid.Dissipation library is founded within the ITEA research


### PR DESCRIPTION
Since Fluid.Dissipation is part of MSL this is no longer necesssary.