### PR TITLE
Issue #2322

### DIFF
--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1067,15 +1067,6 @@ connector to another connector instance, the connecting line has
 the color of the \"ControlBus\" with double width (due to \"thickness=0.5\").
 </p>
 
-<p>
-An <strong>expandable</strong> connector is a connector where the content of the connector
-is constructed by the variables connected to instances of this connector.
-For example, if \"sine.y\" is connected to the \"controlBus\", the following
-menu pops-up in Dymola:
-</p>
-
-<img src=\"modelica://Modelica/Resources/Images/Blocks/BusUsage2.png\"
-     alt=\"BusUsage2.png\">
 
 <p>
 The \"Add variable/New name\" field allows the user to define the name of the signal on
@@ -1088,24 +1079,7 @@ the \"controlBus\". When typing \"realSignal1\" as \"New name\", a connection of
 <p>
 is generated and the \"controlBus\" contains the new signal \"realSignal1\". Modelica tools
 may give more support in order to list potential signals for a connection.
-For example, in Dymola all variables are listed in the menu that are contained in
-connectors which are derived by inheritance from \"controlBus\". Therefore, in
-<a href=\"modelica://Modelica.Blocks.Examples.BusUsage_Utilities.Interfaces\">BusUsage_Utilities.Interfaces</a>
-the expected implementation of the \"ControlBus\" and of the \"SubControlBus\" are given.
-For example \"Internal.ControlBus\" is defined as:
 </p>
-
-<pre>  <strong>expandable connector</strong> StandardControlBus
-    <strong>extends</strong> BusUsage_Utilities.Interfaces.ControlBus;
-
-    <strong>import</strong> SI = Modelica.SIunits;
-    SI.AngularVelocity    realSignal1   \"First Real signal\";
-    SI.Velocity           realSignal2   \"Second Real signal\";
-    Integer               integerSignal \"Integer signal\";
-    Boolean               booleanSignal \"Boolean signal\";
-    StandardSubControlBus subControlBus \"Combined signal\";
-  <strong>end</strong> StandardControlBus;
-</pre>
 
 <p>
 Consequently, when connecting now from \"sine.y\" to \"controlBus\", the menu

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1067,6 +1067,15 @@ connector to another connector instance, the connecting line has
 the color of the \"ControlBus\" with double width (due to \"thickness=0.5\").
 </p>
 
+<p> 
+An <strong>expandable</strong> connector is a connector where the content of the connector 
+is constructed by the variables connected to instances of this connector. 
+For example, if "sine.y" is connected to the "controlBus", a popup may appear:
+</p> 
+
+<img src=\"modelica://Modelica/Resources/Images/Blocks/BusUsage2.png\" 
+     alt=\"BusUsage2.png\"> 
+
 
 <p>
 The \"Add variable/New name\" field allows the user to define the name of the signal on
@@ -1078,8 +1087,24 @@ the \"controlBus\". When typing \"realSignal1\" as \"New name\", a connection of
 
 <p>
 is generated and the \"controlBus\" contains the new signal \"realSignal1\". Modelica tools
-may give more support in order to list potential signals for a connection.
-</p>
+may give more support in order to list potential signals for a connection. Therefore, in 
+<a href=\"modelica://Modelica.Blocks.Examples.BusUsage_Utilities.Interfaces\">BusUsage_Utilities.Interfaces</a> 
+the expected implementation of the \"ControlBus\" and of the \"SubControlBus\" are given. 
+For example \"Internal.ControlBus\" is defined as: 
+</p> 
+ 
+<pre>  <strong>expandable connector</strong> StandardControlBus 
+    <strong>extends</strong> BusUsage_Utilities.Interfaces.ControlBus; 
+ 
+    <strong>import</strong> SI = Modelica.SIunits; 
+    SI.AngularVelocity    realSignal1   \"First Real signal\"; 
+    SI.Velocity           realSignal2   \"Second Real signal\"; 
+    Integer               integerSignal \"Integer signal\"; 
+    Boolean               booleanSignal \"Boolean signal\"; 
+    StandardSubControlBus subControlBus \"Combined signal\"; 
+  <strong>end</strong> StandardControlBus; 
+</pre> 
+</p> 
 
 <p>
 Consequently, when connecting now from \"sine.y\" to \"controlBus\", the menu

--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -135,9 +135,6 @@ The water controller is a simple on-off controller, regulating on the gauge pres
 <p>
 Simulate for 2000 s. When the valve is opened at time t=200, the pump starts turning on and off to keep the reservoir level around 2 meters, which roughly corresponds to a gauge pressure of 200 mbar.
 </p>
-<p>
-If using Dymola, turn off \"Equidistant time grid\" to avoid numerical errors.
-</p>
 
 <img src=\"modelica://Modelica/Resources/Images/Fluid/Examples/PumpingSystem.png\" border=\"1\"
      alt=\"PumpingSystem.png\">

--- a/Modelica/Fluid/package.mo
+++ b/Modelica/Fluid/package.mo
@@ -1732,11 +1732,6 @@ using the recently developed concept
 of stream connectors that results in much more reliable simulations
 (see also <a href=\"modelica://Modelica/Resources/Documentation/Fluid/Stream-Connectors-Overview-Rationale.pdf\">Stream-Connectors-Overview-Rationale.pdf</a>).
 This extension was included in Modelica 3.1.
-As of Jan. 2009, the stream concept is supported in Dymola 7.1.
-It is recommended to use Dymola 7.2 (available since Feb. 2009), or a later Dymola version,
-since this version supports a new annotation to connect very
-conveniently to vectors of connectors.
-Other tool vendors will support the stream concept as well.
 </p>
 
 <p>

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -267,6 +267,24 @@ red box on the lower right side.
 </p>
 
 <p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/UsersGuide/Tutorial/LoopStructures/Fourbar1b.png\" width=\"205\" height=\"107\"> 
+</p> 
+ 
+<p> 
+Whenever loop structures occur, non-linear algebraic 
+equations are present on \"position level\". It is then usually not possible by 
+structural analysis to select states during translation (which is possible for 
+non-loop structures). In the example above, Dymola detects a non-linear 
+algebraic loop of 57 equations and reduces this to a system of 7 coupled 
+algebraic equations. Note, that this is performed without using any 
+\"cut-joints\" as it is usually done in multi-body programs, but by just 
+appropriate symbolic equation manipulation. Via the dynamic dummy derivative 
+method the generalized coordinates on position and velocity level from one of 
+the 7 joints are dynamically selected as states during simulation. Whenever, 
+these two states are no longer appropriate, states from one of the other 
+joints are selected during simulation. 
+</p> 
+<p> 
 The efficiency of loop structures can usually be
 enhanced, if states are statically fixed at translation time. For this
 mechanism, the generalized coordinates of joint j1 (i.e., the

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -267,24 +267,6 @@ red box on the lower right side.
 </p>
 
 <p>
-<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/UsersGuide/Tutorial/LoopStructures/Fourbar1b.png\" width=\"205\" height=\"107\">
-</p>
-
-<p>
-Whenever loop structures occur, non-linear algebraic
-equations are present on \"position level\". It is then usually not possible by
-structural analysis to select states during translation (which is possible for
-non-loop structures). In the example above, Dymola detects a non-linear
-algebraic loop of 57 equations and reduces this to a system of 7 coupled
-algebraic equations. Note, that this is performed without using any
-\"cut-joints\" as it is usually done in multi-body programs, but by just
-appropriate symbolic equation manipulation. Via the dynamic dummy derivative
-method the generalized coordinates on position and velocity level from one of
-the 7 joints are dynamically selected as states during simulation. Whenever,
-these two states are no longer appropriate, states from one of the other
-joints are selected during simulation.
-</p>
-<p>
 The efficiency of loop structures can usually be
 enhanced, if states are statically fixed at translation time. For this
 mechanism, the generalized coordinates of joint j1 (i.e., the

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -1372,9 +1372,7 @@ definition of a fluid library:
 Medium has to be defined. Connectors can only be connected together, if the
 corresponding attributes are either not defined or have identical values. Since
 mediumName is part of the quantity attribute of MassFlowRate, it is not
-possible to connect connectors with different media models together. In Dymola
-this is already checked when models are connected together in the diagram layer
-of the graphical user interface.</p>
+possible to connect connectors with different media models together.</p>
 </html>"));
     end BasicStructure;
 


### PR DESCRIPTION
I removed these old references outlines in the issue:

-  "This extension was included in Modelica 3.1. As of Jan. 2009, the stream concept is supported in Dymola 7.1. It is recommended to use Dymola 7.2 (available since Feb. 2009), or a later Dymola version, since this version supports a new annotation to connect very conveniently to vectors of connectors. Other tool vendors will support the stream concept as well. " in Modelica.Fluid

- " In Dymola this is already checked when models are connected together in the diagram layer of the graphical user interface." in Modelica.Media.UsersGuide.MediumDefinition.BasicStructure

- "For example, if "sine.y" is connected to the "controlBus", the following menu pops-up in Dymola:" in Modelica.Blocks.Examples.BusUsage

- "In the example above, Dymola detects a non-linear algebraic loop of 57 equations and reduces this to a system of 7 coupled algebraic equations. Note, that this is performed without using any "cut-joints" as it is usually done in multi-body programs, but by just appropriate symbolic equation manipulation. Via the dynamic dummy derivative method the generalized coordinates on position and velocity level from one of the 7 joints are dynamically selected as states during simulation. Whenever, these two states are no longer appropriate, states from one of the other joints are selected during simulation. " in Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.Introduction (This info is wrong in others ways - will open ticket)

- "If using Dymola, turn off "Equidistant time grid" to avoid numerical errors. " in Modelica.Fluid.Examples.PumpingSystem

I found other references to the tooling, and the issue itself mentions that there shouldnt be documentation references to tooling, but I'm unsure of what should be kept and what should be removed. Suggestions?