### PR TITLE
Add elementary charge

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -45,6 +45,8 @@ package Constants
   final constant Real N_A(final unit="1/mol") = 6.022140857e23
     "Avogadro constant (previous value: 6.0221415e23)";
   final constant Real mue_0(final unit="N/A2") = 4*pi*1.e-7 "Magnetic constant";
+  final constant Modelica.SIunits.ElectricCharge q=Modelica.Constants.F/Modelica.Constants.N_A
+      "Electron charge (without sign) - 1.602177e-e19 A";
   final constant Real epsilon_0(final unit="F/m") = 1/(mue_0*c*c)
     "Electric constant";
   final constant NonSI.Temperature_degC T_zero=-273.15

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -45,8 +45,8 @@ package Constants
   final constant Real N_A(final unit="1/mol") = 6.022140857e23
     "Avogadro constant (previous value: 6.0221415e23)";
   final constant Real mue_0(final unit="N/A2") = 4*pi*1.e-7 "Magnetic constant";
-  final constant Modelica.SIunits.ElectricCharge q=Modelica.Constants.F/Modelica.Constants.N_A
-      "Electron charge (without sign) - 1.602177e-e19 A";
+  final constant Modelica.SIunits.ElectricCharge e_charge=Modelica.Constants.F/Modelica.Constants.N_A
+      "Elementary charge (electron charge without sign) = 1.602177e-19 A";
   final constant Real epsilon_0(final unit="F/m") = 1/(mue_0*c*c)
     "Electric constant";
   final constant NonSI.Temperature_degC T_zero=-273.15

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -45,10 +45,10 @@ package Constants
   final constant Real N_A(final unit="1/mol") = 6.022140857e23
     "Avogadro constant (previous value: 6.0221415e23)";
   final constant Real mue_0(final unit="N/A2") = 4*pi*1.e-7 "Magnetic constant";
-  final constant Modelica.SIunits.ElectricCharge q = Modelica.Constants.F/Modelica.Constants.N_A
-      "Elementary charge (electron charge without sign) = 1.602177e-19 C";
   final constant Real epsilon_0(final unit="F/m") = 1/(mue_0*c*c)
     "Electric constant";
+  final constant Modelica.SIunits.ElectricCharge q = Modelica.Constants.F/Modelica.Constants.N_A
+      "Elementary charge (electron charge without sign) = 1.602177e-19 C";
   final constant NonSI.Temperature_degC T_zero=-273.15
     "Absolute zero temperature";
   annotation (

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -45,7 +45,7 @@ package Constants
   final constant Real N_A(final unit="1/mol") = 6.022140857e23
     "Avogadro constant (previous value: 6.0221415e23)";
   final constant Real mue_0(final unit="N/A2") = 4*pi*1.e-7 "Magnetic constant";
-  final constant Modelica.SIunits.ElectricCharge e_charge=Modelica.Constants.F/Modelica.Constants.N_A
+  final constant Modelica.SIunits.ElectricCharge q = Modelica.Constants.F/Modelica.Constants.N_A
       "Elementary charge (electron charge without sign) = 1.602177e-19 C";
   final constant Real epsilon_0(final unit="F/m") = 1/(mue_0*c*c)
     "Electric constant";

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -46,7 +46,7 @@ package Constants
     "Avogadro constant (previous value: 6.0221415e23)";
   final constant Real mue_0(final unit="N/A2") = 4*pi*1.e-7 "Magnetic constant";
   final constant Modelica.SIunits.ElectricCharge e_charge=Modelica.Constants.F/Modelica.Constants.N_A
-      "Elementary charge (electron charge without sign) = 1.602177e-19 A";
+      "Elementary charge (electron charge without sign) = 1.602177e-19 C";
   final constant Real epsilon_0(final unit="F/m") = 1/(mue_0*c*c)
     "Electric constant";
   final constant NonSI.Temperature_degC T_zero=-273.15


### PR DESCRIPTION
Closes #2303 by adding elementary charge.

This also prepares for resolving #2207 where the elementary charge is a constant of nature with a fixed value (i.e. not measured), which makes it clearer that it should be in Modelica.Constants.

The major issue is naming - the correct name `e` is taken (by `exp(1)`), but https://en.wikipedia.org/wiki/Elementary_charge lists `q` as an alternative sometimes used. 

After consideration that seems better than inventing a new name like `e_charge`.