### PR TITLE
add missing each in Modelica.Media.Examples.TestOnly.MixIdealGasAir

### DIFF
--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2921,7 +2921,7 @@ points, e.g., when an isentropic reference state is computed.
         p(start=1.0e5, fixed=true));
       Medium.BaseProperties medium2(
         T(start=300.0, fixed=true),
-        X(start={0.2,0.8}, fixed=true),
+        X(start={0.2,0.8}, each fixed=true),
         p(start=2.0e5, fixed=true));
       Medium.SpecificHeatCapacity cp=Medium.specificHeatCapacityCp(medium.state);
       Medium.SpecificHeatCapacity cv=Medium.specificHeatCapacityCv(medium.state);

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2961,7 +2961,7 @@ is given to compare the approximation.
         p(start=1.0e5, fixed=true));
       Medium.BaseProperties medium2(
         T(start=300.0, fixed=true),
-        X(start={0.2,0.1,0.3,0.4}, fixed=true),
+        X(start={0.2,0.1,0.3,0.4}, each fixed=true),
         p(start=2.0e5, fixed=true));
       Medium.SpecificHeatCapacity cp=Medium.specificHeatCapacityCp(state);
       Medium.SpecificHeatCapacity cv=Medium.specificHeatCapacityCv(state);


### PR DESCRIPTION
Because medium2.X is a vector the modification of fixed attribute needs each prefix.