### PR TITLE
ClarifyBreakable in ModelicaReference

### DIFF
--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -3049,7 +3049,7 @@ Connections.branch(A.R,B.R);
 <h4>Description</h4>
 <p>
 Defines a branch from the overdetermined type or record instance <code>R</code> in connector instance <code>A</code> to the corresponding overdetermined type or record instance <code>R</code> in connector instance <code>B</code> for a virtual connection graph.
-These branches are required to be part of the spanning-tree for the virtual connection graph (they do not directly generate equations, but should be combined with equations coupling A.R to B.R), 
+These branches are required to be part of the spanning-tree for the virtual connection graph (they do not directly generate equations, but should be combined with equations coupling <code>A.R</code> to <code>B.R</code>), 
 whereas connect-statements are optional for the spanning-tree (and generate different equations depending on whether they are part of the spanning-tree or not).
 </p>
 <h4>Examples</h4>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2938,7 +2938,7 @@ The same restrictions as for the pre() operator apply.</P>
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
-Connect objects (defines <em>breakable</em> branches)
+Connect objects
 </p>
 <h4>Examples</h4>
 
@@ -3048,7 +3048,9 @@ Connections.branch(A.R,B.R);
 
 <h4>Description</h4>
 <p>
-Defines a non-breakable branch from the overdetermined type or record instance <code>R</code> in connector instance <code>A</code> to the corresponding overdetermined type or record instance <code>R</code> in connector instance <code>B</code> for a virtual connection graph.
+Defines a branch from the overdetermined type or record instance <code>R</code> in connector instance <code>A</code> to the corresponding overdetermined type or record instance <code>R</code> in connector instance <code>B</code> for a virtual connection graph.
+These branches are required to be part of the spanning-tree for the virtual connection graph (they do not directly generate equations, but should be combined with equations coupling A.R to B.R), 
+whereas connect-statements are optional for the spanning-tree (and generate different equations depending on whether they are part of the spanning-tree or not).
 </p>
 <h4>Examples</h4>
 <p>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -3038,7 +3038,7 @@ connected as a pair of scalar connectors.</P>
       extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
-Defines <em>non-breakable</em> branch
+Defines <em>required</em> branch of spanning-tree
 </p>
 
 <h4>Syntax</h4>


### PR DESCRIPTION
Remove "breakable branch" from connect (since it is confusing).
As decided in https://trac.modelica.org/Modelica/ticket/2201

Also try to explain Connections.branch in a clearer way: both that it is required to be part of spanning-tree, whereas connect is optional for the spanning-tree; and also that Connections.branch does not generate equation - but assumes that equations are present; whereas connect generates equations.