### PR TITLE
Move timeScaled computation in TimeTable to equation section

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1952,7 +1952,7 @@ a flange according to a given acceleration.
     end when;
   equation
     assert(size(table, 1) > 0, "No table values defined.");
-    y = a*timeScaled + b;
+    y = a*time/timeScale + b;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1939,7 +1939,6 @@ a flange according to a given acceleration.
       assert(table[1, 1] == 0, "The first point in time has to be set to 0, but is table[1,1] = " + String(table[1, 1]));
     end if;
     when {time >= pre(nextEvent),initial()} then
-      timeScaled := time/timeScale;
       (a,b,nextEventScaled,last) := getInterpolationCoefficients(
           table,
           offset,
@@ -1952,7 +1951,8 @@ a flange according to a given acceleration.
     end when;
   equation
     assert(size(table, 1) > 0, "No table values defined.");
-    y = a*time/timeScale + b;
+    timeScaled = time/timeScale;
+    y = a*timeScaled + b;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1938,8 +1938,8 @@ a flange according to a given acceleration.
     if noEvent(size(table, 1) > 1) then
       assert(table[1, 1] == 0, "The first point in time has to be set to 0, but is table[1,1] = " + String(table[1, 1]));
     end if;
-    timeScaled := time/timeScale;
     when {time >= pre(nextEvent),initial()} then
+      timeScaled := time/timeScale;
       (a,b,nextEventScaled,last) := getInterpolationCoefficients(
           table,
           offset,


### PR DESCRIPTION
The continuous variable `timeScaled` in `Modelica.Blocks.Sources.TimeTable` causes problems in the OpenModelica Compiler during IndexReduction. An easy fix is to keep all variables in the algorithm block discrete, i.e. inside the when-equation. See:
https://trac.openmodelica.org/OpenModelica/ticket/3993
