### PR TITLE
Bug fix for ticket #2377

### DIFF
--- a/Modelica/Media/Incompressible.mo
+++ b/Modelica/Media/Incompressible.mo
@@ -220,7 +220,7 @@ density and heat capacity as functions of temperature.</li>
              " K) is not in the allowed range (" + String(T_min) +
              " K <= T <= " + String(T_max) + " K) required from medium model \""
              + mediumName + "\".");
-      R = Modelica.Constants.R;
+      R = Modelica.Constants.R/MM_const;
       cp = Poly.evaluate(poly_Cp,if TinK then T else T_degC);
       h = if enthalpyOfT then h_T(T) else  h_pT(p,T,densityOfT);
       u = h - (if singleState then  reference_p/d else state.p/d);


### PR DESCRIPTION
Fixes gas constant for table based media to be correct unit. No name changes, they would not be fine for the next minor release.