### PR TITLE
Change propsoal to show calculation equation in icon of Division

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -1109,7 +1109,11 @@ by <em>dividing</em> the two inputs <strong>u1</strong> and <strong>u2</strong>:
             extent={{-150,110},{150,150}},
             textString="%name"),
           Line(points={{-100,60},{-66,60},{-40,30}}, color={0,0,127}),
-          Line(points={{-100,-60},{0,-60},{0,-50}}, color={0,0,127})}),
+          Line(points={{-100,-60},{0,-60},{0,-50}}, color={0,0,127}),
+          Text(
+            extent={{-60,88},{90,60}},
+            lineColor={0,0,255},
+            textString="y = u1 / u2")}),
       Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
               100,100}}), graphics={Rectangle(
               extent={{-100,-100},{100,100}},


### PR DESCRIPTION
Every time I am using ```Modelica.Blocks.Math.Division``` I cannot figure out intuitively whether the output is calculated by ```y = u1 / u2``` or ```y = u2 / u1```. I thus propose to add the calculation formula ```y = u1 / u2``` information to icon (right icon, ```division_proposal```): 

![image](https://user-images.githubusercontent.com/4184218/36643911-543c2508-1a52-11e8-9377-81e8914a2cc8.png)